### PR TITLE
Option fixes

### DIFF
--- a/src/main/resources/css/celia-default.scss
+++ b/src/main/resources/css/celia-default.scss
@@ -14,13 +14,6 @@ $letter-spacing: 0 !default;
 @namespace xml "http://www.w3.org/XML/1998/namespace";
 
 /*
- * Hyphenation
- */
-book {
-	hyphens: auto;
-}
-
-/*
  * Volumes: Maximum length, title page
  */
 @volume {

--- a/src/main/resources/css/celia-default.scss
+++ b/src/main/resources/css/celia-default.scss
@@ -11,6 +11,7 @@ $include-image-groups: false !default;
 $include-captions: false !default;
 $include-production-notes: false !default;
 $letter-spacing: 0 !default;
+$process-noterefs: true !default;
 
 @namespace xml "http://www.w3.org/XML/1998/namespace";
 
@@ -278,19 +279,24 @@ sidebar {
 }
 
 /*
- * Notes and noterefs
+ * Noterefs
  *
  * Noterefs have square brackets around them.
- *
- * Notes can be left as they are. Notes are collected at the end of the book
- * by the subcontractor.
  */
-noteref::before {
-	content: "[";
+@if $process-noterefs {
+	noteref::before {
+		content: "[";
+	}
+	noteref::after {
+		content: "]";
+	}
 }
-noteref::after {
-	content: "]";
-}
+
+/*
+ * Notes
+ *
+ * Notes are moved to the end of the book by the subcontractor.
+ */
 note::before {
 	content: attr(id) ': ';
 }

--- a/src/main/resources/css/celia-default.scss
+++ b/src/main/resources/css/celia-default.scss
@@ -9,6 +9,7 @@ $show-braille-page-numbers: true !default;
 $show-print-page-numbers: false !default;
 $include-image-groups: false !default;
 $include-captions: false !default;
+$include-production-notes: false !default;
 $letter-spacing: 0 !default;
 
 @namespace xml "http://www.w3.org/XML/1998/namespace";
@@ -182,12 +183,14 @@ li {
 /*
  * Producer notes
  */
-prodnote {
-	display: block;
-}
+@if $include-production-notes {
+	prodnote {
+		display: block;
+	}
 
-prodnote::before {
-	content: 'Tuottajan huomautus: ';
+	prodnote::before {
+		content: 'Tuottajan huomautus: ';
+	}
 }
 
 /*

--- a/src/main/resources/xml/dtbook-to-pef.xpl
+++ b/src/main/resources/xml/dtbook-to-pef.xpl
@@ -43,7 +43,7 @@
 
     <p:option name="line-spacing" select="'0'"/>
     <p:option name="letter-spacing" select="'0'"/>
-    <p:option name="hyphenation"/>
+    <p:option name="hyphenation" select="'true'"/>
 
     <p:option name="insert-titlepage" select="'true'"/>
 

--- a/src/main/resources/xml/dtbook-to-pef.xpl
+++ b/src/main/resources/xml/dtbook-to-pef.xpl
@@ -35,8 +35,8 @@
     <p:option name="include-images" select="'false'"/>
     <p:option name="include-captions" select="'false'"/>
 
-    <p:option name="include-note-references" select="'false'"/>
     <p:option name="include-production-notes" select="'false'"/>
+    <p:option name="process-noterefs" select="'true'"/>
 
     <p:option name="show-braille-page-numbers" select="'true'"/>
     <p:option name="show-print-page-numbers" select="'false'"/>

--- a/src/test/xprocspec/test_script.xprocspec
+++ b/src/test/xprocspec/test_script.xprocspec
@@ -1163,13 +1163,85 @@
                   <row/>
                   <row>⠉⠕⠝⠞⠑⠝⠞</row>
                   <row/>
-                  <row>⠀⠀⠃⠇⠁⠀⠃⠇⠁⠷⠼⠁⠾⠀⠃⠇⠁</row>
+		  <row>⠀⠀⠃⠇⠁⠀⠃⠇⠁⠷⠼⠁⠾⠀⠃⠇⠁</row>
                   <row>⠀⠀⠃⠇⠑⠀⠃⠇⠑⠷⠼⠃⠾⠀⠃⠇⠑</row>
                   <row/>
                   <row>⠝⠕⠞⠑⠎</row>
                   <row/>
                   <row>⠼⠁⠒⠀⠠⠠⠃⠇⠁</row>
                   <row>⠼⠃⠒⠀⠠⠠⠃⠇⠑</row>
+                </page>
+              </section>
+            </volume>
+          </body>
+        </pef>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="no-noterefs-processing">
+    <x:call step="celia:dtbook-to-pef">
+      <x:input port="source">
+        <x:document type="inline">
+          <dtbook xmlns="http://www.daisy.org/z3986/2005/dtbook/" xml:lang="fi" version="2005-3">
+            <head>
+	            <meta name="dc:Title" content="title"/>
+	            <meta name="dc:Creator" content="celia"/>
+	          </head>
+            <book>
+              <bodymatter>
+                <level1>
+		  <h1>content</h1>
+		  <p>bla bla<noteref idref="#1">1</noteref> bla</p>
+		  <p>ble ble<noteref idref="#2">2</noteref> ble</p>
+                </level1>
+              </bodymatter>
+	      <endmatter>
+                <h1>notes</h1>
+	        <note id="1">BLA</note>
+	        <note id="2">BLE</note>
+	      </endmatter>
+            </book>
+          </dtbook>
+        </x:document>
+      </x:input>
+      <x:option name="include-brf" select="true()"/>
+      <x:option name="pef-output-dir" select="concat($temp-dir, 'no-noterefs/output-dir/')"/>
+      <x:option name="brf-output-dir" select="concat($temp-dir, 'no-noterefs/output-dir/')"/>
+      <x:option name="temp-dir" select="concat($temp-dir, 'no-noterefs/temp-dir/')"/>
+      <x:option name="insert-titlepage" select="false()"/>
+      <x:option name="toc-depth" select="'0'"/>
+      <x:option name="process-noterefs" select="false()"/>
+    </x:call>
+    <x:context label="pef">
+      <x:document type="file" base-uri="temp-dir" href="no-noterefs/output-dir/test_script.pef"/>
+    </x:context>
+    <x:expect label="result" type="custom" href="http://www.daisy.org/pipeline/modules/braille/pef-utils/library.xpl" step="x:pef-compare">
+      <x:document type="inline">
+        <pef xmlns="http://www.daisy.org/ns/2008/pef" version="2008-1" xml:lang="fi">
+          <head>
+            <meta>
+              <dc:format xmlns:dc="http://purl.org/dc/elements/1.1/">application/x-pef+xml</dc:format>
+              <dc:identifier xmlns:dc="http://purl.org/dc/elements/1.1/">identifier?</dc:identifier>
+              <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">title</dc:title>
+              <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">celia</dc:creator>
+            </meta>
+          </head>
+          <body>
+            <volume cols="27" rows="30" rowgap="0" duplex="true">
+              <section>
+                <page>
+                  <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠁</row>
+                  <row/>
+                  <row>⠉⠕⠝⠞⠑⠝⠞</row>
+                  <row/>
+                  <row>⠀⠀⠃⠇⠁⠀⠃⠇⠁⠼⠁⠀⠃⠇⠁</row>
+                  <row>⠀⠀⠃⠇⠑⠀⠃⠇⠑⠼⠃⠀⠃⠇⠑</row>
+                  <row/>
+                  <row>⠝⠕⠞⠑⠎</row>
+                  <row/>
+                  <row>⠼⠁⠒⠀⠠⠠⠃⠇⠁</row>
+		  <row>⠼⠃⠒⠀⠠⠠⠃⠇⠑</row>
                 </page>
               </section>
             </volume>

--- a/src/test/xprocspec/test_script.xprocspec
+++ b/src/test/xprocspec/test_script.xprocspec
@@ -194,6 +194,7 @@
       <x:option name="temp-dir" select="concat($temp-dir, 'prodnotes/temp-dir/')"/>
       <x:option name="insert-titlepage" select="false()"/>
       <x:option name="toc-depth" select="'0'"/>
+      <x:option name="include-production-notes" select="true()"/>
     </x:call>
     <x:context label="pef">
       <x:document type="file" base-uri="temp-dir" href="prodnotes/output-dir/test_script.pef"/>
@@ -216,6 +217,63 @@
                   <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠁</row>
                   <row>⠠⠞⠥⠕⠞⠞⠁⠚⠁⠝⠀⠓⠥⠕⠍⠁⠥⠞⠥⠎⠒⠀⠃⠇⠁⠀</row>
                   <row>⠃⠇⠁⠀⠃⠇⠁</row>
+                </page>
+              </section>
+            </volume>
+          </body>
+        </pef>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="skip-prodnotes">
+    <x:call step="celia:dtbook-to-pef">
+      <x:input port="source">
+        <x:document type="inline">
+          <dtbook xmlns="http://www.daisy.org/z3986/2005/dtbook/" xml:lang="fi" version="2005-3">
+            <head>
+	            <meta name="dc:Title" content="title"/>
+	            <meta name="dc:Creator" content="celia"/>
+	          </head>
+            <book>
+              <bodymatter>
+                <level1>
+		  <p>a</p>
+		  <prodnote>bla bla bla</prodnote>
+                </level1>
+              </bodymatter>
+            </book>
+          </dtbook>
+        </x:document>
+      </x:input>
+      <x:option name="include-brf" select="true()"/>
+      <x:option name="pef-output-dir" select="concat($temp-dir, 'skip-prodnotes/output-dir/')"/>
+      <x:option name="brf-output-dir" select="concat($temp-dir, 'skip-prodnotes/output-dir/')"/>
+      <x:option name="temp-dir" select="concat($temp-dir, 'skip-prodnotes/temp-dir/')"/>
+      <x:option name="insert-titlepage" select="false()"/>
+      <x:option name="toc-depth" select="'0'"/>
+      <x:option name="include-production-notes" select="false()"/>
+    </x:call>
+    <x:context label="pef">
+      <x:document type="file" base-uri="temp-dir" href="skip-prodnotes/output-dir/test_script.pef"/>
+    </x:context>
+    <x:expect label="result" type="custom" href="http://www.daisy.org/pipeline/modules/braille/pef-utils/library.xpl" step="x:pef-compare">
+      <x:document type="inline">
+        <pef xmlns="http://www.daisy.org/ns/2008/pef" version="2008-1" xml:lang="fi">
+          <head>
+            <meta>
+              <dc:format xmlns:dc="http://purl.org/dc/elements/1.1/">application/x-pef+xml</dc:format>
+              <dc:identifier xmlns:dc="http://purl.org/dc/elements/1.1/">identifier?</dc:identifier>
+              <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">title</dc:title>
+              <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">celia</dc:creator>
+            </meta>
+          </head>
+	  <body>
+            <volume cols="27" rows="30" rowgap="0" duplex="true">
+              <section>
+                <page>
+                  <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠁</row>
+                  <row>⠀⠀⠁</row>
                 </page>
               </section>
             </volume>
@@ -698,6 +756,7 @@
       <x:option name="include-image-groups" select="true()"/>
       <x:option name="include-images" select="false()"/>
       <x:option name="include-captions" select="true()"/>
+      <x:option name="include-production-notes" select="true()"/>
     </x:call>
     <x:context label="pef">
       <x:document type="file" base-uri="temp-dir" href="images/output-dir/test_script.pef"/>


### PR DESCRIPTION
fix #5 
- Moves hyphenation control from CSS to options
- Fixes include-production-notes-option
- Renames include-note-references to process-noterefs, which is arguably a bit clearer, and fixes the option.
