### PR TITLE
add option for adding 'id: ' before notes

### DIFF
--- a/src/main/resources/css/celia-default.scss
+++ b/src/main/resources/css/celia-default.scss
@@ -13,6 +13,7 @@ $include-production-notes: false !default;
 $letter-spacing: 0 !default;
 $skip-typography: false !default;
 $process-noterefs: true !default;
+$process-notes: true !default;
 
 @namespace xml "http://www.w3.org/XML/1998/namespace";
 
@@ -297,8 +298,10 @@ sidebar {
  *
  * Notes are moved to the end of the book by the subcontractor.
  */
-note::before {
-	content: attr(id) ': ';
+@if $process-notes {
+	note::before {
+		content: attr(id) ': ';
+	}
 }
 
 /*

--- a/src/main/resources/xml/dtbook-to-pef.xpl
+++ b/src/main/resources/xml/dtbook-to-pef.xpl
@@ -40,6 +40,7 @@
 
     <p:option name="include-production-notes" select="'false'"/>
     <p:option name="process-noterefs" select="'true'"/>
+    <p:option name="process-notes" select="'true'"/>
 
     <p:option name="show-braille-page-numbers" select="'true'"/>
     <p:option name="show-print-page-numbers" select="'false'"/>

--- a/src/test/xprocspec/test_script.xprocspec
+++ b/src/test/xprocspec/test_script.xprocspec
@@ -1251,6 +1251,78 @@
     </x:expect>
   </x:scenario>
 
+  <x:scenario label="no-notes-processing">
+    <x:call step="celia:dtbook-to-pef">
+      <x:input port="source">
+        <x:document type="inline">
+          <dtbook xmlns="http://www.daisy.org/z3986/2005/dtbook/" xml:lang="fi" version="2005-3">
+            <head>
+	            <meta name="dc:Title" content="title"/>
+	            <meta name="dc:Creator" content="celia"/>
+	          </head>
+            <book>
+              <bodymatter>
+                <level1>
+		  <h1>content</h1>
+		  <p>bla bla<noteref idref="#1">1</noteref> bla</p>
+		  <p>ble ble<noteref idref="#2">2</noteref> ble</p>
+                </level1>
+              </bodymatter>
+	      <endmatter>
+                <h1>notes</h1>
+	        <note id="1">BLA</note>
+	        <note id="2">BLE</note>
+	      </endmatter>
+            </book>
+          </dtbook>
+        </x:document>
+      </x:input>
+      <x:option name="include-brf" select="true()"/>
+      <x:option name="pef-output-dir" select="concat($temp-dir, 'no-notes/output-dir/')"/>
+      <x:option name="brf-output-dir" select="concat($temp-dir, 'no-notes/output-dir/')"/>
+      <x:option name="temp-dir" select="concat($temp-dir, 'no-notes/temp-dir/')"/>
+      <x:option name="insert-titlepage" select="false()"/>
+      <x:option name="toc-depth" select="'0'"/>
+      <x:option name="process-notes" select="false()"/>
+    </x:call>
+    <x:context label="pef">
+      <x:document type="file" base-uri="temp-dir" href="no-notes/output-dir/test_script.pef"/>
+    </x:context>
+    <x:expect label="result" type="custom" href="http://www.daisy.org/pipeline/modules/braille/pef-utils/library.xpl" step="x:pef-compare">
+      <x:document type="inline">
+        <pef xmlns="http://www.daisy.org/ns/2008/pef" version="2008-1" xml:lang="fi">
+          <head>
+            <meta>
+              <dc:format xmlns:dc="http://purl.org/dc/elements/1.1/">application/x-pef+xml</dc:format>
+              <dc:identifier xmlns:dc="http://purl.org/dc/elements/1.1/">identifier?</dc:identifier>
+              <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">title</dc:title>
+              <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">celia</dc:creator>
+            </meta>
+          </head>
+          <body>
+            <volume cols="27" rows="30" rowgap="0" duplex="true">
+              <section>
+                <page>
+                  <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠁</row>
+                  <row/>
+                  <row>⠉⠕⠝⠞⠑⠝⠞</row>
+                  <row/>
+		  <row>⠀⠀⠃⠇⠁⠀⠃⠇⠁⠷⠼⠁⠾⠀⠃⠇⠁</row>
+		  <row>⠀⠀⠃⠇⠑⠀⠃⠇⠑⠷⠼⠃⠾⠀⠃⠇⠑</row>
+                  <row/>
+                  <row>⠝⠕⠞⠑⠎</row>
+                  <row/>
+                  <row>⠠⠠⠃⠇⠁</row>
+		  <row>⠠⠠⠃⠇⠑</row>
+                </page>
+              </section>
+            </volume>
+          </body>
+        </pef>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
   <!-- <tr>s, <line>s and <li>s that won't fit on one line -->
   <x:scenario label="long-lines">
     <x:call step="celia:dtbook-to-pef">


### PR DESCRIPTION
fix #19
I know this will raise the same remarks as #16 and #20, but I'm opening this nevertheless, because I think these option names require some discussion.
