### PR TITLE
Volume breaking fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.daisy.pipeline.modules.braille</groupId>
     <artifactId>braille-modules-parent</artifactId>
-    <version>1.9.11</version>
+    <version>1.9.12</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   </parent>
 
   <artifactId>mod-celia</artifactId>
-  <version>1.3.0-SNAPSHOT</version>
+  <version>1.3.0</version>
   <packaging>bundle</packaging>
 
   <name>DP2 Braille Modules :: mod-celia</name>
@@ -255,4 +255,8 @@
       </plugin>
     </plugins>
   </build>
+
+  <scm>
+    <tag>v1.3.0</tag>
+  </scm>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   </parent>
 
   <artifactId>mod-celia</artifactId>
-  <version>1.2.1-SNAPSHOT</version>
+  <version>1.3.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
 
   <name>DP2 Braille Modules :: mod-celia</name>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   </parent>
 
   <artifactId>mod-celia</artifactId>
-  <version>1.3.0</version>
+  <version>1.3.1-SNAPSHOT</version>
   <packaging>bundle</packaging>
 
   <name>DP2 Braille Modules :: mod-celia</name>
@@ -255,8 +255,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <scm>
-    <tag>v1.3.0</tag>
-  </scm>
 </project>

--- a/src/main/java/fi/celia/pipeline/braille/impl/CeliaTranslator.java
+++ b/src/main/java/fi/celia/pipeline/braille/impl/CeliaTranslator.java
@@ -19,6 +19,7 @@ import static org.daisy.pipeline.braille.common.AbstractTransformProvider.util.l
 import static org.daisy.pipeline.braille.common.AbstractTransformProvider.util.logSelect;
 import org.daisy.pipeline.braille.common.BrailleTranslator;
 import org.daisy.pipeline.braille.common.BrailleTranslatorProvider;
+import org.daisy.pipeline.braille.common.CSSStyledText;
 import org.daisy.pipeline.braille.common.Query;
 import org.daisy.pipeline.braille.common.Query.Feature;
 import org.daisy.pipeline.braille.common.Query.MutableQuery;

--- a/src/main/resources/xml/dtbook-to-pef.xpl
+++ b/src/main/resources/xml/dtbook-to-pef.xpl
@@ -52,6 +52,7 @@
 
     <p:option name="preprocess-tables" select="'false'"/>
 
+    <p:option name="pad-volume-endings" select="'false'"/>
     <p:option name="make-volumes-divisible-by-four" select="'false'"/>
 
     <p:option name="skip-typography" select="'false'"/>
@@ -138,6 +139,7 @@
         <p:pipe step="input-options" port="result"/>
       </p:input>
       <p:with-option name="make-volumes-divisible-by-four" select="$make-volumes-divisible-by-four"/>
+      <p:with-option name="pad-volume-endings" select="$pad-volume-endings"/>
       <p:with-option name="duplex" select="$duplex"/>
     </celia:post-processing>
 

--- a/src/main/resources/xml/dtbook-to-pef.xpl
+++ b/src/main/resources/xml/dtbook-to-pef.xpl
@@ -52,6 +52,8 @@
 
     <p:option name="preprocess-tables" select="'false'"/>
 
+    <p:option name="make-volumes-divisible-by-four" select="'false'"/>
+
     <p:option name="skip-typography" select="'false'"/>
 
     <p:option name="toc-depth" select="'2'"/>
@@ -126,6 +128,17 @@
 	  <p:pipe step="input-options" port="result"/>
 	</p:input>
     </px:dtbook-to-pef.convert>
+
+    <!-- ================== -->
+    <!-- PEF POSTPROCESSING -->
+    <!-- ================== -->
+
+    <celia:post-processing>
+      <p:input port="parameters">
+        <p:pipe step="input-options" port="result"/>
+      </p:input>
+      <p:with-option name="make-volumes-divisible-by-four" select="$make-volumes-divisible-by-four"/>
+    </celia:post-processing>
 
     <!-- ========= -->
     <!-- STORE PEF -->

--- a/src/main/resources/xml/dtbook-to-pef.xpl
+++ b/src/main/resources/xml/dtbook-to-pef.xpl
@@ -138,6 +138,7 @@
         <p:pipe step="input-options" port="result"/>
       </p:input>
       <p:with-option name="make-volumes-divisible-by-four" select="$make-volumes-divisible-by-four"/>
+      <p:with-option name="duplex" select="$duplex"/>
     </celia:post-processing>
 
     <!-- ========= -->

--- a/src/main/resources/xml/insert-empty-pages.xsl
+++ b/src/main/resources/xml/insert-empty-pages.xsl
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+		xmlns:pef="http://www.daisy.org/ns/2008/pef"
+		xmlns="http://www.daisy.org/ns/2008/pef"
+		xpath-default-namespace="http://www.daisy.org/ns/2008/pef"
+		exclude-result-prefixes="#all"
+		version="2.0">
+	
+	<xsl:output indent="yes"/>
+
+	<xsl:param name="duplex" select="'true'"/>
+
+	<!-- Generic copy-all template -->
+	<xsl:template match="@*|node()">
+		<xsl:copy>
+			<xsl:apply-templates select="@*|node()"/>
+		</xsl:copy>
+	</xsl:template>
+
+        <xsl:template match="volume/section/page[last()]">
+	  <xsl:copy-of select="."/>
+	  <xsl:choose>
+	    <xsl:when test="$duplex = 'true'">
+	      <xsl:choose>
+                <!-- Insert a single empty page if the last page is already empty,
+	             otherwise insert an empty sheet, ie. 2 empty pages -->
+	        <xsl:when test="not(*) and not(normalize-space())">
+	          <page/>
+	        </xsl:when>
+	        <xsl:otherwise>
+	          <page/>
+	          <page/>
+	        </xsl:otherwise>
+	      </xsl:choose>
+	    </xsl:when>
+	    <xsl:otherwise>
+	      <!-- When printing single-sided, just add a single empty page
+	           if the last page is not empty. -->
+	      <xsl:if test="* or normalize-space()">
+	        <page/>
+	      </xsl:if>
+	    </xsl:otherwise>
+	  </xsl:choose>
+	</xsl:template>
+
+
+</xsl:stylesheet>

--- a/src/main/resources/xml/library.xpl
+++ b/src/main/resources/xml/library.xpl
@@ -3,5 +3,6 @@
 <p:library xmlns:p="http://www.w3.org/ns/xproc" xmlns:c="http://www.w3.org/ns/xproc-step" version="1.0">
     
     <p:import href="pre-processing.xpl"/>
+    <p:import href="post-processing.xpl"/>
     
 </p:library>

--- a/src/main/resources/xml/post-processing.xpl
+++ b/src/main/resources/xml/post-processing.xpl
@@ -12,6 +12,7 @@
     <p:input port="source"/>
     <p:input port="parameters" kind="parameter"/>
     
+    <p:option name="pad-volume-endings" select="'false'"/>
     <p:option name="make-volumes-divisible-by-four" select="'false'"/>
     <p:option name="duplex" select="'true'"/>
     
@@ -26,10 +27,28 @@
             <p:pipe port="source" step="main"/>
         </p:input>
     </p:identity>
+
+    <p:choose>
+      <p:when test="$pad-volume-endings='true'">
+        <px:message message="Inserting empty pages at the end of the volumes to protect the print"/>
+        <p:xslt>
+	  <p:with-param name="duplex" select="$duplex"/>
+          <p:input port="parameters">
+            <p:pipe port="result" step="parameters"/>
+          </p:input>
+          <p:input port="stylesheet">
+            <p:document href="insert-empty-pages.xsl"/>
+          </p:input>
+        </p:xslt>
+      </p:when>
+      <p:otherwise>
+        <px:message message="Skipping insertion of protection pages"/>
+      </p:otherwise>
+    </p:choose>
     
     <p:choose>
       <p:when test="$make-volumes-divisible-by-four='true'">
-        <px:message message="Running PEF post-processing"/>
+        <px:message message="Inserting pages to make the volumes divisible by four"/>
         <p:xslt>
 	  <p:with-param name="duplex" select="$duplex"/>
           <p:input port="parameters">
@@ -41,7 +60,7 @@
         </p:xslt>
       </p:when>
       <p:otherwise>
-        <px:message message="Skipping PEF post-processing"/>
+        <px:message message="Skipping volume length correction"/>
       </p:otherwise>
     </p:choose>
 

--- a/src/main/resources/xml/post-processing.xpl
+++ b/src/main/resources/xml/post-processing.xpl
@@ -13,6 +13,7 @@
     <p:input port="parameters" kind="parameter"/>
     
     <p:option name="make-volumes-divisible-by-four" select="'false'"/>
+    <p:option name="duplex" select="'true'"/>
     
     <p:output port="result"/>
     
@@ -30,6 +31,7 @@
       <p:when test="$make-volumes-divisible-by-four='true'">
         <px:message message="Running PEF post-processing"/>
         <p:xslt>
+	  <p:with-param name="duplex" select="$duplex"/>
           <p:input port="parameters">
             <p:pipe port="result" step="parameters"/>
           </p:input>

--- a/src/main/resources/xml/post-processing.xpl
+++ b/src/main/resources/xml/post-processing.xpl
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<p:declare-step type="celia:post-processing" version="1.0"
+                 xmlns:celia="http://www.celia.fi"
+                 xmlns:p="http://www.w3.org/ns/xproc"
+                 xmlns:px="http://www.daisy.org/ns/pipeline/xproc"
+                 xmlns:d="http://www.daisy.org/ns/pipeline/data"
+                 xmlns:c="http://www.w3.org/ns/xproc-step"
+                 xmlns:pef="http://www.daisy.org/ns/2008/pef"
+                 exclude-inline-prefixes="#all"
+                 name="main">
+    
+    <p:input port="source"/>
+    <p:input port="parameters" kind="parameter"/>
+    
+    <p:option name="make-volumes-divisible-by-four" select="'false'"/>
+    
+    <p:output port="result"/>
+    
+    <p:import href="http://www.daisy.org/pipeline/modules/common-utils/library.xpl"/>
+        
+    <p:parameters name="parameters"/>
+    
+    <p:identity>
+        <p:input port="source">
+            <p:pipe port="source" step="main"/>
+        </p:input>
+    </p:identity>
+    
+    <p:choose>
+      <p:when test="$make-volumes-divisible-by-four='true'">
+        <px:message message="Running PEF post-processing"/>
+        <p:xslt>
+          <p:input port="parameters">
+            <p:pipe port="result" step="parameters"/>
+          </p:input>
+          <p:input port="stylesheet">
+            <p:document href="postprocess-volumes.xsl"/>
+          </p:input>
+        </p:xslt>
+      </p:when>
+      <p:otherwise>
+        <px:message message="Skipping PEF post-processing"/>
+      </p:otherwise>
+    </p:choose>
+
+    <px:message message="Finished running Celia-specific post-processing steps" severity="DEBUG"/>
+    
+</p:declare-step>

--- a/src/main/resources/xml/postprocess-volumes.xsl
+++ b/src/main/resources/xml/postprocess-volumes.xsl
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+		xmlns:dc="http://purl.org/dc/elements/1.1/"
+		xmlns:html="http://www.w3.org/1999/xhtml"
+		xmlns:dtb="http://www.daisy.org/z3986/2005/dtbook/"
+		xmlns:pef="http://www.daisy.org/ns/2008/pef"
+		xmlns="http://www.daisy.org/ns/2008/pef"
+		xpath-default-namespace="http://www.daisy.org/ns/2008/pef"
+		exclude-result-prefixes="#all"
+		version="2.0">
+	
+	<xsl:output indent="yes"/>
+
+    <!-- Variables -->
+    <xsl:variable name="OUTPUT_NAMESPACE" as="xs:string" select="namespace-uri(/*)"/>
+	
+	<!-- Generic copy-all template -->
+	<xsl:template match="@*|node()">
+		<xsl:copy>
+			<xsl:apply-templates select="@*|node()"/>
+		</xsl:copy>
+	</xsl:template>
+
+        <!-- Insert empty pages if number of pages mod 4 != 0 -->
+        <xsl:template match="volume/section/page[last()]">
+	  <xsl:copy-of select="."/>
+	  <xsl:if test="(count(../../section/page) mod 4) = 3">
+	    <page/>
+	  </xsl:if>
+	  <xsl:if test="(count(../../section/page) mod 4) = 2">
+	    <page/>
+	    <page/>
+	  </xsl:if>
+	  <xsl:if test="(count(../../section/page) mod 4) = 1">
+	    <page/>
+	    <page/>
+	    <page/>
+	  </xsl:if>
+	</xsl:template>
+
+
+</xsl:stylesheet>

--- a/src/main/resources/xml/postprocess-volumes.xsl
+++ b/src/main/resources/xml/postprocess-volumes.xsl
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:xs="http://www.w3.org/2001/XMLSchema"
-		xmlns:dc="http://purl.org/dc/elements/1.1/"
-		xmlns:html="http://www.w3.org/1999/xhtml"
-		xmlns:dtb="http://www.daisy.org/z3986/2005/dtbook/"
 		xmlns:pef="http://www.daisy.org/ns/2008/pef"
 		xmlns="http://www.daisy.org/ns/2008/pef"
 		xpath-default-namespace="http://www.daisy.org/ns/2008/pef"
@@ -12,9 +8,8 @@
 	
 	<xsl:output indent="yes"/>
 
-    <!-- Variables -->
-    <xsl:variable name="OUTPUT_NAMESPACE" as="xs:string" select="namespace-uri(/*)"/>
-	
+	<xsl:param name="duplex" select="'true'"/>
+
 	<!-- Generic copy-all template -->
 	<xsl:template match="@*|node()">
 		<xsl:copy>
@@ -25,18 +20,27 @@
         <!-- Insert empty pages if number of pages mod 4 != 0 -->
         <xsl:template match="volume/section/page[last()]">
 	  <xsl:copy-of select="."/>
-	  <xsl:if test="(count(../../section/page) mod 4) = 3">
-	    <page/>
-	  </xsl:if>
-	  <xsl:if test="(count(../../section/page) mod 4) = 2">
-	    <page/>
-	    <page/>
-	  </xsl:if>
-	  <xsl:if test="(count(../../section/page) mod 4) = 1">
-	    <page/>
-	    <page/>
-	    <page/>
-	  </xsl:if>
+	  <xsl:choose>
+	    <xsl:when test="$duplex = 'true'">
+	      <xsl:if test="(count(../../section/page) mod 4) = 3">
+	        <page/>
+	      </xsl:if>
+	      <xsl:if test="(count(../../section/page) mod 4) = 2">
+	        <page/>
+	        <page/>
+	      </xsl:if>
+	      <xsl:if test="(count(../../section/page) mod 4) = 1">
+	        <page/>
+	        <page/>
+	        <page/>
+	      </xsl:if>
+	    </xsl:when>
+	    <xsl:otherwise>
+	      <xsl:if test="(count(../../section/page) mod 2) = 1">
+	        <page/>
+	      </xsl:if>
+	    </xsl:otherwise>
+	  </xsl:choose>
 	</xsl:template>
 
 

--- a/src/test/java/HyphenationTest.java
+++ b/src/test/java/HyphenationTest.java
@@ -63,7 +63,7 @@ public class HyphenationTest {
 			= ((LibhyphenHyphenator.Provider)context.getService(context.getServiceReference(LibhyphenHyphenator.Provider.class.getName())))
 			.get(query("(table:'hyph-fi.dic')")).iterator().next();
 		for(String[] testCase : testCases) {
-			assertEquals(testCase[0], testCase[1], hyphenator.transform(new String[]{testCase[2]})[0]);
+			assertEquals(testCase[0], testCase[1], hyphenator.asFullHyphenator().transform(new String[]{testCase[2]})[0]);
 		}
 	}
 	
@@ -75,6 +75,7 @@ public class HyphenationTest {
 		for(String[] testCase : testCases) {
 			assertEquals(testCase[0], testCase[1],
 			             texhyphProvider.get(query("(table:'hyph-fi.properties')")).iterator().next()
+			                            .asFullHyphenator()
 			                            .transform(new String[]{testCase[2]})[0]);
 		}
 	}

--- a/src/test/xprocspec/test_script.xprocspec
+++ b/src/test/xprocspec/test_script.xprocspec
@@ -1784,4 +1784,243 @@
     </x:expect>
   </x:scenario>
 
+  <x:scenario label="volumes-divisible-by-four">
+    <x:call step="celia:dtbook-to-pef">
+      <x:input port="source">
+        <x:document type="file" href="../resources/test.xml">
+        </x:document>
+      </x:input>
+      <x:option name="temp-dir" select="$temp-dir"/>
+      <x:option name="pef-output-dir" select="concat($temp-dir, 'volumes-divisible-by-four/output-dir/')"/>
+      <x:option name="toc-depth" select="'0'"/>
+      <x:option name="page-height" select="'8'"/>
+      <x:option name="maximum-number-of-sheets" select="'4'"/>
+      <x:option name="insert-titlepage" select="false()"/>
+      <x:option name="make-volumes-divisible-by-four" select="true()"/>
+    </x:call>
+    <x:context label="pef">
+      <x:document type="file" base-uri="temp-dir" href="volumes-divisible-by-four/output-dir/test.pef"/>
+    </x:context>
+    <x:expect label="result" type="custom" href="http://www.daisy.org/pipeline/modules/braille/pef-utils/library.xpl" step="x:pef-compare">
+      <x:document type="inline">
+        <pef xmlns="http://www.daisy.org/ns/2008/pef" version="2008-1" xml:lang="fi">
+          <head xmlns:dc="http://purl.org/dc/elements/1.1/">
+            <meta>
+              <dc:format xmlns:dc="http://purl.org/dc/elements/1.1/">application/x-pef+xml</dc:format>
+              <dc:identifier xmlns:dc="http://purl.org/dc/elements/1.1/">identifier?</dc:identifier>
+              <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">Kirja</dc:title>
+              <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">John Doe</dc:creator>
+              <dc:language xmlns:dc="http://purl.org/dc/elements/1.1/">fi</dc:language>
+              <dc:publisher xmlns:dc="http://purl.org/dc/elements/1.1/">Celia</dc:publisher>
+            </meta>
+          </head>
+          <body>
+            <volume cols="27" rows="8" rowgap="0" duplex="true">
+              <section>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠁</row>
+                    <row>⠠⠅⠊⠗⠚⠁</row>
+                    <row/>
+                    <row>⠠⠚⠕⠓⠝⠀⠠⠙⠕⠑</row>
+                    <row/>
+                    <row>⠠⠁⠇⠅⠥⠞⠊⠑⠙⠕⠞</row>
+                    <row/>
+                    <row>⠠⠠⠅⠥⠎⠞⠁⠝⠞⠁⠚⠁⠀⠠⠠⠏⠁⠊⠅⠅⠁</row>
+                </page>
+                <page>
+                    <row>⠼⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row/>
+                    <row>⠠⠧⠊⠊⠙⠑⠎⠀⠏⠁⠊⠝⠕⠎⠂⠀⠼⠃⠚⠁⠑</row>
+                    <row/>
+                    <row>⠠⠞⠥⠕⠞⠞⠁⠚⠁⠒⠀⠠⠉⠑⠇⠊⠁⠀⠤⠀⠠⠝⠜⠅⠪⠤</row>
+                    <row>⠧⠁⠍⠍⠁⠊⠎⠞⠑⠝⠀⠅⠊⠗⠚⠁⠎⠞⠕⠀⠼⠃⠚⠁⠋</row>
+                </page>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠉</row>
+                    <row/>
+                    <row>⠠⠅⠜⠽⠞⠞⠪⠕⠊⠅⠑⠥⠎</row>
+                    <row/>
+                    <row>⠠⠞⠜⠍⠜⠀⠅⠊⠗⠚⠁⠀⠕⠝⠀⠧⠁⠇⠍⠊⠎⠞⠑⠞⠞⠥⠀</row>
+                    <row>⠞⠑⠅⠊⠚⠜⠝⠕⠊⠅⠑⠥⠎⠇⠁⠊⠝⠀⠼⠁⠛⠄⠀⠏⠽⠤</row>
+                    <row>⠅⠜⠇⠜⠝⠀⠝⠕⠚⠁⠇⠇⠁⠀⠚⠁⠀⠕⠝⠀⠞⠁⠗⠅⠕⠊⠤</row>
+                    <row>⠞⠑⠞⠞⠥⠀⠁⠊⠝⠕⠁⠎⠞⠁⠁⠝⠀⠝⠜⠅⠪⠧⠁⠍⠤</row>
+                </page>
+                <page>
+                    <row>⠼⠙⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row>⠍⠁⠊⠎⠞⠑⠝⠀⠚⠁⠀⠍⠥⠊⠙⠑⠝⠀⠇⠥⠅⠑⠍⠊⠤</row>
+                    <row>⠎⠑⠎⠞⠑⠊⠎⠞⠑⠝⠀⠅⠜⠽⠞⠞⠪⠪⠝⠄</row>
+                    <row/>
+                    <row>⠠⠅⠥⠎⠞⠁⠝⠞⠁⠚⠁⠀⠑⠎⠊⠞⠞⠑⠇⠑⠑</row>
+                    <row/>
+                    <row>⠠⠇⠕⠗⠑⠍⠀⠊⠏⠎⠥⠍⠀⠙⠕⠇⠕⠗⠀⠎⠊⠞⠀</row>
+                    <row>⠁⠍⠑⠞⠂⠀⠉⠕⠝⠎⠑⠉⠞⠑⠞⠥⠗⠀⠁⠙⠊⠤</row>
+                </page>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠑</row>
+                    <row>⠏⠊⠎⠉⠊⠝⠛⠀⠑⠇⠊⠞⠂⠀⠎⠑⠙⠀⠙⠕⠀⠑⠊⠥⠎⠤</row>
+                    <row>⠍⠕⠙⠀⠞⠑⠍⠏⠕⠗⠀⠊⠝⠉⠊⠙⠊⠙⠥⠝⠞⠀⠥⠞⠀</row>
+                    <row>⠇⠁⠃⠕⠗⠑⠀⠑⠞⠀⠙⠕⠇⠕⠗⠑⠀⠍⠁⠛⠝⠁⠀</row>
+                    <row>⠁⠇⠊⠟⠥⠁⠄⠀⠠⠥⠞⠀⠑⠝⠊⠍⠀⠁⠙⠀⠍⠊⠝⠊⠍⠀</row>
+                    <row>⠧⠑⠝⠊⠁⠍⠂⠀⠟⠥⠊⠎⠀⠝⠕⠎⠞⠗⠥⠙⠀</row>
+                    <row>⠑⠭⠑⠗⠉⠊⠞⠁⠞⠊⠕⠝⠀⠥⠇⠇⠁⠍⠉⠕⠀⠇⠁⠃⠕⠤</row>
+                    <row>⠗⠊⠎⠀⠝⠊⠎⠊⠀⠥⠞⠀⠁⠇⠊⠟⠥⠊⠏⠀⠑⠭⠀⠑⠁⠀</row>
+                </page>
+                <page>
+                    <row>⠼⠋⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row>⠉⠕⠍⠍⠕⠙⠕⠀⠉⠕⠝⠎⠑⠟⠥⠁⠞⠄⠀⠠⠙⠥⠊⠎⠀</row>
+                    <row>⠁⠥⠞⠑⠀⠊⠗⠥⠗⠑⠀⠙⠕⠇⠕⠗⠀⠊⠝⠀⠗⠑⠏⠗⠑⠤</row>
+                    <row>⠓⠑⠝⠙⠑⠗⠊⠞⠀⠊⠝⠀⠧⠕⠇⠥⠏⠞⠁⠞⠑⠀⠧⠑⠇⠊⠞</row>
+                    <row>⠑⠎⠎⠑⠀⠉⠊⠇⠇⠥⠍⠀⠙⠕⠇⠕⠗⠑⠀⠑⠥⠀⠋⠥⠛⠊⠤</row>
+                    <row>⠁⠞⠀⠝⠥⠇⠇⠁⠀⠏⠁⠗⠊⠁⠞⠥⠗⠄⠀⠠⠑⠭⠉⠑⠏⠤</row>
+                    <row>⠞⠑⠥⠗⠀⠎⠊⠝⠞⠀⠕⠉⠉⠁⠑⠉⠁⠞⠀⠉⠥⠏⠊⠙⠁⠤</row>
+                    <row>⠞⠁⠞⠀⠝⠕⠝⠀⠏⠗⠕⠊⠙⠑⠝⠞⠂⠀⠎⠥⠝⠞⠀⠊⠝⠀</row>
+                </page>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠛</row>
+                    <row>⠉⠥⠇⠏⠁⠀⠟⠥⠊⠀⠕⠋⠋⠊⠉⠊⠁⠀⠙⠑⠎⠑⠗⠥⠝⠞⠀</row>
+                    <row>⠍⠕⠇⠇⠊⠞⠀⠁⠝⠊⠍⠀⠊⠙⠀⠑⠎⠞⠀⠇⠁⠃⠕⠗⠥⠍⠄</row>
+                    <row/>
+                    <row>⠼⠁⠀⠠⠇⠕⠗⠑⠍⠀⠊⠏⠎⠥⠍</row>
+                    <row/>
+                    <row>⠀⠀⠠⠇⠕⠗⠑⠍⠀⠊⠏⠎⠥⠍⠀⠙⠕⠇⠕⠗⠀⠎⠊⠞⠀</row>
+                    <row>⠁⠍⠑⠞⠂⠀⠉⠕⠝⠎⠑⠉⠞⠑⠞⠥⠗⠀⠁⠙⠊⠤</row>
+                </page>
+                <page>
+                    <row>⠼⠓⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row>⠏⠊⠎⠉⠊⠝⠛⠀⠑⠇⠊⠞⠂⠀⠎⠑⠙⠀⠙⠕⠀⠑⠊⠥⠎⠤</row>
+                    <row>⠍⠕⠙⠀⠞⠑⠍⠏⠕⠗⠀⠊⠝⠉⠊⠙⠊⠙⠥⠝⠞⠀⠥⠞⠀</row>
+                    <row>⠇⠁⠃⠕⠗⠑⠀⠑⠞⠀⠙⠕⠇⠕⠗⠑⠀⠍⠁⠛⠝⠁⠀</row>
+                    <row>⠁⠇⠊⠟⠥⠁⠄⠀⠠⠥⠞⠀⠑⠝⠊⠍⠀⠁⠙⠀⠍⠊⠝⠊⠍⠀</row>
+                    <row>⠧⠑⠝⠊⠁⠍⠂⠀⠟⠥⠊⠎⠀⠝⠕⠎⠞⠗⠥⠙⠀</row>
+                    <row>⠑⠭⠑⠗⠉⠊⠞⠁⠞⠊⠕⠝⠀⠥⠇⠇⠁⠍⠉⠕⠀⠇⠁⠃⠕⠤</row>
+                    <row>⠗⠊⠎⠀⠝⠊⠎⠊⠀⠥⠞⠀⠁⠇⠊⠟⠥⠊⠏⠀⠑⠭⠀⠑⠁⠀</row>
+                </page>
+              </section>
+            </volume>
+            <volume cols="27" rows="8" rowgap="0" duplex="true">
+              <section>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠊</row>
+                    <row>⠉⠕⠍⠍⠕⠙⠕⠀⠉⠕⠝⠎⠑⠟⠥⠁⠞⠄⠀⠠⠙⠥⠊⠎⠀</row>
+                    <row>⠁⠥⠞⠑⠀⠊⠗⠥⠗⠑⠀⠙⠕⠇⠕⠗⠀⠊⠝⠀⠗⠑⠏⠗⠑⠤</row>
+                    <row>⠓⠑⠝⠙⠑⠗⠊⠞⠀⠊⠝⠀⠧⠕⠇⠥⠏⠞⠁⠞⠑⠀⠧⠑⠇⠊⠞</row>
+                    <row>⠑⠎⠎⠑⠀⠉⠊⠇⠇⠥⠍⠀⠙⠕⠇⠕⠗⠑⠀⠑⠥⠀⠋⠥⠛⠊⠤</row>
+                    <row>⠁⠞⠀⠝⠥⠇⠇⠁⠀⠏⠁⠗⠊⠁⠞⠥⠗⠄⠀⠠⠑⠭⠉⠑⠏⠤</row>
+                    <row>⠞⠑⠥⠗⠀⠎⠊⠝⠞⠀⠕⠉⠉⠁⠑⠉⠁⠞⠀⠉⠥⠏⠊⠙⠁⠤</row>
+                    <row>⠞⠁⠞⠀⠝⠕⠝⠀⠏⠗⠕⠊⠙⠑⠝⠞⠂⠀⠎⠥⠝⠞⠀⠊⠝⠀</row>
+                </page>
+                <page>
+                    <row>⠼⠁⠚⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row>⠉⠥⠇⠏⠁⠀⠟⠥⠊⠀⠕⠋⠋⠊⠉⠊⠁⠀⠙⠑⠎⠑⠗⠥⠝⠞⠀</row>
+                    <row>⠍⠕⠇⠇⠊⠞⠀⠁⠝⠊⠍⠀⠊⠙⠀⠑⠎⠞⠀⠇⠁⠃⠕⠗⠥⠍⠄</row>
+                    <row/>
+                    <row>⠠⠇⠕⠗⠑⠍⠀⠊⠏⠎⠥⠍</row>
+                    <row/>
+                    <row>⠀⠀⠠⠇⠕⠗⠑⠍⠀⠊⠏⠎⠥⠍⠀⠙⠕⠇⠕⠗⠀⠎⠊⠞⠀</row>
+                    <row>⠁⠍⠑⠞⠂⠀⠉⠕⠝⠎⠑⠉⠞⠑⠞⠥⠗⠀⠁⠙⠊⠤</row>
+                </page>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠁⠁</row>
+                    <row>⠏⠊⠎⠉⠊⠝⠛⠀⠑⠇⠊⠞⠂⠀⠎⠑⠙⠀⠙⠕⠀⠑⠊⠥⠎⠤</row>
+                    <row>⠍⠕⠙⠀⠞⠑⠍⠏⠕⠗⠀⠊⠝⠉⠊⠙⠊⠙⠥⠝⠞⠀⠥⠞⠀</row>
+                    <row>⠇⠁⠃⠕⠗⠑⠀⠑⠞⠀⠙⠕⠇⠕⠗⠑⠀⠍⠁⠛⠝⠁⠀</row>
+                    <row>⠁⠇⠊⠟⠥⠁⠄⠀⠠⠥⠞⠀⠑⠝⠊⠍⠀⠁⠙⠀⠍⠊⠝⠊⠍⠀</row>
+                    <row>⠧⠑⠝⠊⠁⠍⠂⠀⠟⠥⠊⠎⠀⠝⠕⠎⠞⠗⠥⠙⠀</row>
+                    <row>⠑⠭⠑⠗⠉⠊⠞⠁⠞⠊⠕⠝⠀⠥⠇⠇⠁⠍⠉⠕⠀⠇⠁⠃⠕⠤</row>
+                    <row>⠗⠊⠎⠀⠝⠊⠎⠊⠀⠥⠞⠀⠁⠇⠊⠟⠥⠊⠏⠀⠑⠭⠀⠑⠁⠀</row>
+                </page>
+                <page>
+                    <row>⠼⠁⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row>⠉⠕⠍⠍⠕⠙⠕⠀⠉⠕⠝⠎⠑⠟⠥⠁⠞⠄⠀⠠⠙⠥⠊⠎⠀</row>
+                    <row>⠁⠥⠞⠑⠀⠊⠗⠥⠗⠑⠀⠙⠕⠇⠕⠗⠀⠊⠝⠀⠗⠑⠏⠗⠑⠤</row>
+                    <row>⠓⠑⠝⠙⠑⠗⠊⠞⠀⠊⠝⠀⠧⠕⠇⠥⠏⠞⠁⠞⠑⠀⠧⠑⠇⠊⠞</row>
+                    <row>⠑⠎⠎⠑⠀⠉⠊⠇⠇⠥⠍⠀⠙⠕⠇⠕⠗⠑⠀⠑⠥⠀⠋⠥⠛⠊⠤</row>
+                    <row>⠁⠞⠀⠝⠥⠇⠇⠁⠀⠏⠁⠗⠊⠁⠞⠥⠗⠄⠀⠠⠑⠭⠉⠑⠏⠤</row>
+                    <row>⠞⠑⠥⠗⠀⠎⠊⠝⠞⠀⠕⠉⠉⠁⠑⠉⠁⠞⠀⠉⠥⠏⠊⠙⠁⠤</row>
+                    <row>⠞⠁⠞⠀⠝⠕⠝⠀⠏⠗⠕⠊⠙⠑⠝⠞⠂⠀⠎⠥⠝⠞⠀⠊⠝⠀</row>
+                </page>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠁⠉</row>
+                    <row>⠉⠥⠇⠏⠁⠀⠟⠥⠊⠀⠕⠋⠋⠊⠉⠊⠁⠀⠙⠑⠎⠑⠗⠥⠝⠞⠀</row>
+                    <row>⠍⠕⠇⠇⠊⠞⠀⠁⠝⠊⠍⠀⠊⠙⠀⠑⠎⠞⠀⠇⠁⠃⠕⠗⠥⠍⠄</row>
+                    <row>⠀⠀⠠⠇⠕⠗⠑⠍⠀⠊⠏⠎⠥⠍⠀⠙⠕⠇⠕⠗⠀⠎⠊⠞⠀</row>
+                    <row>⠁⠍⠑⠞⠂⠀⠉⠕⠝⠎⠑⠉⠞⠑⠞⠥⠗⠀⠁⠙⠊⠤</row>
+                    <row>⠏⠊⠎⠉⠊⠝⠛⠀⠑⠇⠊⠞⠂⠀⠎⠑⠙⠀⠙⠕⠀⠑⠊⠥⠎⠤</row>
+                    <row>⠍⠕⠙⠀⠞⠑⠍⠏⠕⠗⠀⠊⠝⠉⠊⠙⠊⠙⠥⠝⠞⠀⠥⠞⠀</row>
+                    <row>⠇⠁⠃⠕⠗⠑⠀⠑⠞⠀⠙⠕⠇⠕⠗⠑⠀⠍⠁⠛⠝⠁⠀</row>
+                </page>
+                <page>
+                    <row>⠼⠁⠙⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row>⠁⠇⠊⠟⠥⠁⠄⠀⠠⠥⠞⠀⠑⠝⠊⠍⠀⠁⠙⠀⠍⠊⠝⠊⠍⠀</row>
+                    <row>⠧⠑⠝⠊⠁⠍⠂⠀⠟⠥⠊⠎⠀⠝⠕⠎⠞⠗⠥⠙⠀</row>
+                    <row>⠑⠭⠑⠗⠉⠊⠞⠁⠞⠊⠕⠝⠀⠥⠇⠇⠁⠍⠉⠕⠀⠇⠁⠃⠕⠤</row>
+                    <row>⠗⠊⠎⠀⠝⠊⠎⠊⠀⠥⠞⠀⠁⠇⠊⠟⠥⠊⠏⠀⠑⠭⠀⠑⠁⠀</row>
+                    <row>⠉⠕⠍⠍⠕⠙⠕⠀⠉⠕⠝⠎⠑⠟⠥⠁⠞⠄⠀⠠⠙⠥⠊⠎⠀</row>
+                    <row>⠁⠥⠞⠑⠀⠊⠗⠥⠗⠑⠀⠙⠕⠇⠕⠗⠀⠊⠝⠀⠗⠑⠏⠗⠑⠤</row>
+                    <row>⠓⠑⠝⠙⠑⠗⠊⠞⠀⠊⠝⠀⠧⠕⠇⠥⠏⠞⠁⠞⠑⠀⠧⠑⠇⠊⠞</row>
+                </page>
+		<page/>
+		<page/>
+              </section>
+            </volume>
+            <volume cols="27" rows="8" rowgap="0" duplex="true">
+              <section>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠁⠑</row>
+                    <row>⠑⠎⠎⠑⠀⠉⠊⠇⠇⠥⠍⠀⠙⠕⠇⠕⠗⠑⠀⠑⠥⠀⠋⠥⠛⠊⠤</row>
+                    <row>⠁⠞⠀⠝⠥⠇⠇⠁⠀⠏⠁⠗⠊⠁⠞⠥⠗⠄⠀⠠⠑⠭⠉⠑⠏⠤</row>
+                    <row>⠞⠑⠥⠗⠀⠎⠊⠝⠞⠀⠕⠉⠉⠁⠑⠉⠁⠞⠀⠉⠥⠏⠊⠙⠁⠤</row>
+                    <row>⠞⠁⠞⠀⠝⠕⠝⠀⠏⠗⠕⠊⠙⠑⠝⠞⠂⠀⠎⠥⠝⠞⠀⠊⠝⠀</row>
+                    <row>⠉⠥⠇⠏⠁⠀⠟⠥⠊⠀⠕⠋⠋⠊⠉⠊⠁⠀⠙⠑⠎⠑⠗⠥⠝⠞⠀</row>
+                    <row>⠍⠕⠇⠇⠊⠞⠀⠁⠝⠊⠍⠀⠊⠙⠀⠑⠎⠞⠀⠇⠁⠃⠕⠗⠥⠍⠄</row>
+                </page>
+                <page>
+                    <row>⠼⠁⠋⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row/>
+                    <row>⠠⠇⠕⠏⠏⠥⠎⠁⠝⠁⠞</row>
+                    <row/>
+                    <row>⠀⠀⠠⠇⠕⠗⠑⠍⠀⠊⠏⠎⠥⠍⠀⠙⠕⠇⠕⠗⠀⠎⠊⠞⠀</row>
+                    <row>⠁⠍⠑⠞⠂⠀⠉⠕⠝⠎⠑⠉⠞⠑⠞⠥⠗⠀⠁⠙⠊⠤</row>
+                    <row>⠏⠊⠎⠉⠊⠝⠛⠀⠑⠇⠊⠞⠂⠀⠎⠑⠙⠀⠙⠕⠀⠑⠊⠥⠎⠤</row>
+                    <row>⠍⠕⠙⠀⠞⠑⠍⠏⠕⠗⠀⠊⠝⠉⠊⠙⠊⠙⠥⠝⠞⠀⠥⠞⠀</row>
+                </page>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠁⠛</row>
+                    <row>⠇⠁⠃⠕⠗⠑⠀⠑⠞⠀⠙⠕⠇⠕⠗⠑⠀⠍⠁⠛⠝⠁⠀</row>
+                    <row>⠁⠇⠊⠟⠥⠁⠄⠀⠠⠥⠞⠀⠑⠝⠊⠍⠀⠁⠙⠀⠍⠊⠝⠊⠍⠀</row>
+                    <row>⠧⠑⠝⠊⠁⠍⠂⠀⠟⠥⠊⠎⠀⠝⠕⠎⠞⠗⠥⠙⠀</row>
+                    <row>⠑⠭⠑⠗⠉⠊⠞⠁⠞⠊⠕⠝⠀⠥⠇⠇⠁⠍⠉⠕⠀⠇⠁⠃⠕⠤</row>
+                    <row>⠗⠊⠎⠀⠝⠊⠎⠊⠀⠥⠞⠀⠁⠇⠊⠟⠥⠊⠏⠀⠑⠭⠀⠑⠁⠀</row>
+                    <row>⠉⠕⠍⠍⠕⠙⠕⠀⠉⠕⠝⠎⠑⠟⠥⠁⠞⠄⠀⠠⠙⠥⠊⠎⠀</row>
+                    <row>⠁⠥⠞⠑⠀⠊⠗⠥⠗⠑⠀⠙⠕⠇⠕⠗⠀⠊⠝⠀⠗⠑⠏⠗⠑⠤</row>
+                </page>
+                <page>
+                    <row>⠼⠁⠓⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row>⠓⠑⠝⠙⠑⠗⠊⠞⠀⠊⠝⠀⠧⠕⠇⠥⠏⠞⠁⠞⠑⠀⠧⠑⠇⠊⠞</row>
+                    <row>⠑⠎⠎⠑⠀⠉⠊⠇⠇⠥⠍⠀⠙⠕⠇⠕⠗⠑⠀⠑⠥⠀⠋⠥⠛⠊⠤</row>
+                    <row>⠁⠞⠀⠝⠥⠇⠇⠁⠀⠏⠁⠗⠊⠁⠞⠥⠗⠄⠀⠠⠑⠭⠉⠑⠏⠤</row>
+                    <row>⠞⠑⠥⠗⠀⠎⠊⠝⠞⠀⠕⠉⠉⠁⠑⠉⠁⠞⠀⠉⠥⠏⠊⠙⠁⠤</row>
+                    <row>⠞⠁⠞⠀⠝⠕⠝⠀⠏⠗⠕⠊⠙⠑⠝⠞⠂⠀⠎⠥⠝⠞⠀⠊⠝⠀</row>
+                    <row>⠉⠥⠇⠏⠁⠀⠟⠥⠊⠀⠕⠋⠋⠊⠉⠊⠁⠀⠙⠑⠎⠑⠗⠥⠝⠞⠀</row>
+                    <row>⠍⠕⠇⠇⠊⠞⠀⠁⠝⠊⠍⠀⠊⠙⠀⠑⠎⠞⠀⠇⠁⠃⠕⠗⠥⠍⠄</row>
+                </page>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠁⠊</row>
+                    <row/>
+                    <row>⠠⠅⠊⠗⠚⠁⠝⠀⠇⠕⠏⠏⠥</row>
+                    <row/>
+                    <row>⠀⠀⠠⠞⠜⠓⠜⠝⠀⠏⠜⠜⠞⠞⠽⠊⠀⠅⠊⠗⠚⠁⠀</row>
+                    <row>⠠⠅⠊⠗⠚⠁</row>
+                </page>
+		<page/>
+		<page/>
+		<page/>
+              </section>
+            </volume>
+          </body>
+        </pef>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
 </x:description>

--- a/src/test/xprocspec/test_script.xprocspec
+++ b/src/test/xprocspec/test_script.xprocspec
@@ -2268,4 +2268,480 @@
     </x:expect>
   </x:scenario>
 
+  <x:scenario label="pad-volume-endings">
+    <x:call step="celia:dtbook-to-pef">
+      <x:input port="source">
+        <x:document type="file" href="../resources/test.xml">
+        </x:document>
+      </x:input>
+      <x:option name="temp-dir" select="$temp-dir"/>
+      <x:option name="pef-output-dir" select="concat($temp-dir, 'pad-volume-endings/output-dir/')"/>
+      <x:option name="toc-depth" select="'0'"/>
+      <x:option name="page-height" select="'8'"/>
+      <x:option name="maximum-number-of-sheets" select="'8'"/>
+      <x:option name="insert-titlepage" select="false()"/>
+      <x:option name="make-volumes-divisible-by-four" select="false()"/>
+      <x:option name="pad-volume-endings" select="true()"/>
+    </x:call>
+    <x:context label="pef">
+      <x:document type="file" base-uri="temp-dir" href="pad-volume-endings/output-dir/test.pef"/>
+    </x:context>
+    <x:expect label="result" type="custom" href="http://www.daisy.org/pipeline/modules/braille/pef-utils/library.xpl" step="x:pef-compare">
+      <x:document type="inline">
+        <pef xmlns="http://www.daisy.org/ns/2008/pef" xml:lang="fi" version="2008-1">
+    <head>
+        <meta>
+            <dc:format xmlns:dc="http://purl.org/dc/elements/1.1/">application/x-pef+xml</dc:format>
+          <dc:identifier xmlns:dc="http://purl.org/dc/elements/1.1/">identifier?</dc:identifier>
+          <dc:date xmlns:dc="http://purl.org/dc/elements/1.1/">2016-05-19</dc:date>
+          <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">Kirja</dc:title>
+          <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">John Doe</dc:creator>
+          <dc:language xmlns:dc="http://purl.org/dc/elements/1.1/">fi</dc:language>
+          <dc:publisher xmlns:dc="http://purl.org/dc/elements/1.1/">Celia</dc:publisher>
+        </meta>
+    </head>
+    <body>
+        <volume cols="27" rows="8" rowgap="0" duplex="true">
+            <section>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠁</row>
+                    <row>⠠⠅⠊⠗⠚⠁</row>
+                    <row/>
+                    <row>⠠⠚⠕⠓⠝⠀⠠⠙⠕⠑</row>
+                    <row/>
+                    <row>⠠⠁⠇⠅⠥⠞⠊⠑⠙⠕⠞</row>
+                    <row/>
+                    <row>⠠⠠⠅⠥⠎⠞⠁⠝⠞⠁⠚⠁⠀⠠⠠⠏⠁⠊⠅⠅⠁</row>
+                </page>
+                <page>
+                    <row>⠼⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row/>
+                    <row>⠠⠧⠊⠊⠙⠑⠎⠀⠏⠁⠊⠝⠕⠎⠂⠀⠼⠃⠚⠁⠑</row>
+                    <row/>
+                    <row>⠠⠞⠥⠕⠞⠞⠁⠚⠁⠒⠀⠠⠉⠑⠇⠊⠁⠀⠤⠀⠠⠝⠜⠅⠪⠤</row>
+                    <row>⠧⠁⠍⠍⠁⠊⠎⠞⠑⠝⠀⠅⠊⠗⠚⠁⠎⠞⠕⠀⠼⠃⠚⠁⠋</row>
+                </page>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠉</row>
+                    <row/>
+                    <row>⠠⠅⠜⠽⠞⠞⠪⠕⠊⠅⠑⠥⠎</row>
+                    <row/>
+                    <row>⠠⠞⠜⠍⠜⠀⠅⠊⠗⠚⠁⠀⠕⠝⠀⠧⠁⠇⠍⠊⠎⠞⠑⠞⠞⠥⠀</row>
+                    <row>⠞⠑⠅⠊⠚⠜⠝⠕⠊⠅⠑⠥⠎⠇⠁⠊⠝⠀⠼⠁⠛⠄⠀⠏⠽⠤</row>
+                    <row>⠅⠜⠇⠜⠝⠀⠝⠕⠚⠁⠇⠇⠁⠀⠚⠁⠀⠕⠝⠀⠞⠁⠗⠅⠕⠊⠤</row>
+                    <row>⠞⠑⠞⠞⠥⠀⠁⠊⠝⠕⠁⠎⠞⠁⠁⠝⠀⠝⠜⠅⠪⠧⠁⠍⠤</row>
+                </page>
+                <page>
+                    <row>⠼⠙⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row>⠍⠁⠊⠎⠞⠑⠝⠀⠚⠁⠀⠍⠥⠊⠙⠑⠝⠀⠇⠥⠅⠑⠍⠊⠤</row>
+                    <row>⠎⠑⠎⠞⠑⠊⠎⠞⠑⠝⠀⠅⠜⠽⠞⠞⠪⠪⠝⠄</row>
+                    <row/>
+                    <row>⠠⠅⠥⠎⠞⠁⠝⠞⠁⠚⠁⠀⠑⠎⠊⠞⠞⠑⠇⠑⠑</row>
+                    <row/>
+                    <row>⠠⠇⠕⠗⠑⠍⠀⠊⠏⠎⠥⠍⠀⠙⠕⠇⠕⠗⠀⠎⠊⠞⠀</row>
+                    <row>⠁⠍⠑⠞⠂⠀⠉⠕⠝⠎⠑⠉⠞⠑⠞⠥⠗⠀⠁⠙⠊⠤</row>
+                </page>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠑</row>
+                    <row>⠏⠊⠎⠉⠊⠝⠛⠀⠑⠇⠊⠞⠂⠀⠎⠑⠙⠀⠙⠕⠀⠑⠊⠥⠎⠤</row>
+                    <row>⠍⠕⠙⠀⠞⠑⠍⠏⠕⠗⠀⠊⠝⠉⠊⠙⠊⠙⠥⠝⠞⠀⠥⠞⠀</row>
+                    <row>⠇⠁⠃⠕⠗⠑⠀⠑⠞⠀⠙⠕⠇⠕⠗⠑⠀⠍⠁⠛⠝⠁⠀</row>
+                    <row>⠁⠇⠊⠟⠥⠁⠄⠀⠠⠥⠞⠀⠑⠝⠊⠍⠀⠁⠙⠀⠍⠊⠝⠊⠍⠀</row>
+                    <row>⠧⠑⠝⠊⠁⠍⠂⠀⠟⠥⠊⠎⠀⠝⠕⠎⠞⠗⠥⠙⠀</row>
+                    <row>⠑⠭⠑⠗⠉⠊⠞⠁⠞⠊⠕⠝⠀⠥⠇⠇⠁⠍⠉⠕⠀⠇⠁⠃⠕⠤</row>
+                    <row>⠗⠊⠎⠀⠝⠊⠎⠊⠀⠥⠞⠀⠁⠇⠊⠟⠥⠊⠏⠀⠑⠭⠀⠑⠁⠀</row>
+                </page>
+                <page>
+                    <row>⠼⠋⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row>⠉⠕⠍⠍⠕⠙⠕⠀⠉⠕⠝⠎⠑⠟⠥⠁⠞⠄⠀⠠⠙⠥⠊⠎⠀</row>
+                    <row>⠁⠥⠞⠑⠀⠊⠗⠥⠗⠑⠀⠙⠕⠇⠕⠗⠀⠊⠝⠀⠗⠑⠏⠗⠑⠤</row>
+                    <row>⠓⠑⠝⠙⠑⠗⠊⠞⠀⠊⠝⠀⠧⠕⠇⠥⠏⠞⠁⠞⠑⠀⠧⠑⠇⠊⠞</row>
+                    <row>⠑⠎⠎⠑⠀⠉⠊⠇⠇⠥⠍⠀⠙⠕⠇⠕⠗⠑⠀⠑⠥⠀⠋⠥⠛⠊⠤</row>
+                    <row>⠁⠞⠀⠝⠥⠇⠇⠁⠀⠏⠁⠗⠊⠁⠞⠥⠗⠄⠀⠠⠑⠭⠉⠑⠏⠤</row>
+                    <row>⠞⠑⠥⠗⠀⠎⠊⠝⠞⠀⠕⠉⠉⠁⠑⠉⠁⠞⠀⠉⠥⠏⠊⠙⠁⠤</row>
+                    <row>⠞⠁⠞⠀⠝⠕⠝⠀⠏⠗⠕⠊⠙⠑⠝⠞⠂⠀⠎⠥⠝⠞⠀⠊⠝⠀</row>
+                </page>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠛</row>
+                    <row>⠉⠥⠇⠏⠁⠀⠟⠥⠊⠀⠕⠋⠋⠊⠉⠊⠁⠀⠙⠑⠎⠑⠗⠥⠝⠞⠀</row>
+                    <row>⠍⠕⠇⠇⠊⠞⠀⠁⠝⠊⠍⠀⠊⠙⠀⠑⠎⠞⠀⠇⠁⠃⠕⠗⠥⠍⠄</row>
+                    <row/>
+                    <row>⠼⠁⠀⠠⠇⠕⠗⠑⠍⠀⠊⠏⠎⠥⠍</row>
+                    <row/>
+                    <row>⠀⠀⠠⠇⠕⠗⠑⠍⠀⠊⠏⠎⠥⠍⠀⠙⠕⠇⠕⠗⠀⠎⠊⠞⠀</row>
+                    <row>⠁⠍⠑⠞⠂⠀⠉⠕⠝⠎⠑⠉⠞⠑⠞⠥⠗⠀⠁⠙⠊⠤</row>
+                </page>
+                <page>
+                    <row>⠼⠓⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row>⠏⠊⠎⠉⠊⠝⠛⠀⠑⠇⠊⠞⠂⠀⠎⠑⠙⠀⠙⠕⠀⠑⠊⠥⠎⠤</row>
+                    <row>⠍⠕⠙⠀⠞⠑⠍⠏⠕⠗⠀⠊⠝⠉⠊⠙⠊⠙⠥⠝⠞⠀⠥⠞⠀</row>
+                    <row>⠇⠁⠃⠕⠗⠑⠀⠑⠞⠀⠙⠕⠇⠕⠗⠑⠀⠍⠁⠛⠝⠁⠀</row>
+                    <row>⠁⠇⠊⠟⠥⠁⠄⠀⠠⠥⠞⠀⠑⠝⠊⠍⠀⠁⠙⠀⠍⠊⠝⠊⠍⠀</row>
+                    <row>⠧⠑⠝⠊⠁⠍⠂⠀⠟⠥⠊⠎⠀⠝⠕⠎⠞⠗⠥⠙⠀</row>
+                    <row>⠑⠭⠑⠗⠉⠊⠞⠁⠞⠊⠕⠝⠀⠥⠇⠇⠁⠍⠉⠕⠀⠇⠁⠃⠕⠤</row>
+                    <row>⠗⠊⠎⠀⠝⠊⠎⠊⠀⠥⠞⠀⠁⠇⠊⠟⠥⠊⠏⠀⠑⠭⠀⠑⠁⠀</row>
+                </page>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠊</row>
+                    <row>⠉⠕⠍⠍⠕⠙⠕⠀⠉⠕⠝⠎⠑⠟⠥⠁⠞⠄⠀⠠⠙⠥⠊⠎⠀</row>
+                    <row>⠁⠥⠞⠑⠀⠊⠗⠥⠗⠑⠀⠙⠕⠇⠕⠗⠀⠊⠝⠀⠗⠑⠏⠗⠑⠤</row>
+                    <row>⠓⠑⠝⠙⠑⠗⠊⠞⠀⠊⠝⠀⠧⠕⠇⠥⠏⠞⠁⠞⠑⠀⠧⠑⠇⠊⠞</row>
+                    <row>⠑⠎⠎⠑⠀⠉⠊⠇⠇⠥⠍⠀⠙⠕⠇⠕⠗⠑⠀⠑⠥⠀⠋⠥⠛⠊⠤</row>
+                    <row>⠁⠞⠀⠝⠥⠇⠇⠁⠀⠏⠁⠗⠊⠁⠞⠥⠗⠄⠀⠠⠑⠭⠉⠑⠏⠤</row>
+                    <row>⠞⠑⠥⠗⠀⠎⠊⠝⠞⠀⠕⠉⠉⠁⠑⠉⠁⠞⠀⠉⠥⠏⠊⠙⠁⠤</row>
+                    <row>⠞⠁⠞⠀⠝⠕⠝⠀⠏⠗⠕⠊⠙⠑⠝⠞⠂⠀⠎⠥⠝⠞⠀⠊⠝⠀</row>
+                </page>
+                <page>
+                    <row>⠼⠁⠚⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row>⠉⠥⠇⠏⠁⠀⠟⠥⠊⠀⠕⠋⠋⠊⠉⠊⠁⠀⠙⠑⠎⠑⠗⠥⠝⠞⠀</row>
+                    <row>⠍⠕⠇⠇⠊⠞⠀⠁⠝⠊⠍⠀⠊⠙⠀⠑⠎⠞⠀⠇⠁⠃⠕⠗⠥⠍⠄</row>
+                    <row/>
+                    <row>⠠⠇⠕⠗⠑⠍⠀⠊⠏⠎⠥⠍</row>
+                    <row/>
+                    <row>⠀⠀⠠⠇⠕⠗⠑⠍⠀⠊⠏⠎⠥⠍⠀⠙⠕⠇⠕⠗⠀⠎⠊⠞⠀</row>
+                    <row>⠁⠍⠑⠞⠂⠀⠉⠕⠝⠎⠑⠉⠞⠑⠞⠥⠗⠀⠁⠙⠊⠤</row>
+                </page>
+                <page/>
+                <page/>
+            </section>
+        </volume>
+        <volume cols="27" rows="8" rowgap="0" duplex="true">
+            <section>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠁⠁</row>
+                    <row>⠏⠊⠎⠉⠊⠝⠛⠀⠑⠇⠊⠞⠂⠀⠎⠑⠙⠀⠙⠕⠀⠑⠊⠥⠎⠤</row>
+                    <row>⠍⠕⠙⠀⠞⠑⠍⠏⠕⠗⠀⠊⠝⠉⠊⠙⠊⠙⠥⠝⠞⠀⠥⠞⠀</row>
+                    <row>⠇⠁⠃⠕⠗⠑⠀⠑⠞⠀⠙⠕⠇⠕⠗⠑⠀⠍⠁⠛⠝⠁⠀</row>
+                    <row>⠁⠇⠊⠟⠥⠁⠄⠀⠠⠥⠞⠀⠑⠝⠊⠍⠀⠁⠙⠀⠍⠊⠝⠊⠍⠀</row>
+                    <row>⠧⠑⠝⠊⠁⠍⠂⠀⠟⠥⠊⠎⠀⠝⠕⠎⠞⠗⠥⠙⠀</row>
+                    <row>⠑⠭⠑⠗⠉⠊⠞⠁⠞⠊⠕⠝⠀⠥⠇⠇⠁⠍⠉⠕⠀⠇⠁⠃⠕⠤</row>
+                    <row>⠗⠊⠎⠀⠝⠊⠎⠊⠀⠥⠞⠀⠁⠇⠊⠟⠥⠊⠏⠀⠑⠭⠀⠑⠁⠀</row>
+                </page>
+                <page>
+                    <row>⠼⠁⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row>⠉⠕⠍⠍⠕⠙⠕⠀⠉⠕⠝⠎⠑⠟⠥⠁⠞⠄⠀⠠⠙⠥⠊⠎⠀</row>
+                    <row>⠁⠥⠞⠑⠀⠊⠗⠥⠗⠑⠀⠙⠕⠇⠕⠗⠀⠊⠝⠀⠗⠑⠏⠗⠑⠤</row>
+                    <row>⠓⠑⠝⠙⠑⠗⠊⠞⠀⠊⠝⠀⠧⠕⠇⠥⠏⠞⠁⠞⠑⠀⠧⠑⠇⠊⠞</row>
+                    <row>⠑⠎⠎⠑⠀⠉⠊⠇⠇⠥⠍⠀⠙⠕⠇⠕⠗⠑⠀⠑⠥⠀⠋⠥⠛⠊⠤</row>
+                    <row>⠁⠞⠀⠝⠥⠇⠇⠁⠀⠏⠁⠗⠊⠁⠞⠥⠗⠄⠀⠠⠑⠭⠉⠑⠏⠤</row>
+                    <row>⠞⠑⠥⠗⠀⠎⠊⠝⠞⠀⠕⠉⠉⠁⠑⠉⠁⠞⠀⠉⠥⠏⠊⠙⠁⠤</row>
+                    <row>⠞⠁⠞⠀⠝⠕⠝⠀⠏⠗⠕⠊⠙⠑⠝⠞⠂⠀⠎⠥⠝⠞⠀⠊⠝⠀</row>
+                </page>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠁⠉</row>
+                    <row>⠉⠥⠇⠏⠁⠀⠟⠥⠊⠀⠕⠋⠋⠊⠉⠊⠁⠀⠙⠑⠎⠑⠗⠥⠝⠞⠀</row>
+                    <row>⠍⠕⠇⠇⠊⠞⠀⠁⠝⠊⠍⠀⠊⠙⠀⠑⠎⠞⠀⠇⠁⠃⠕⠗⠥⠍⠄</row>
+                    <row>⠀⠀⠠⠇⠕⠗⠑⠍⠀⠊⠏⠎⠥⠍⠀⠙⠕⠇⠕⠗⠀⠎⠊⠞⠀</row>
+                    <row>⠁⠍⠑⠞⠂⠀⠉⠕⠝⠎⠑⠉⠞⠑⠞⠥⠗⠀⠁⠙⠊⠤</row>
+                    <row>⠏⠊⠎⠉⠊⠝⠛⠀⠑⠇⠊⠞⠂⠀⠎⠑⠙⠀⠙⠕⠀⠑⠊⠥⠎⠤</row>
+                    <row>⠍⠕⠙⠀⠞⠑⠍⠏⠕⠗⠀⠊⠝⠉⠊⠙⠊⠙⠥⠝⠞⠀⠥⠞⠀</row>
+                    <row>⠇⠁⠃⠕⠗⠑⠀⠑⠞⠀⠙⠕⠇⠕⠗⠑⠀⠍⠁⠛⠝⠁⠀</row>
+                </page>
+                <page>
+                    <row>⠼⠁⠙⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row>⠁⠇⠊⠟⠥⠁⠄⠀⠠⠥⠞⠀⠑⠝⠊⠍⠀⠁⠙⠀⠍⠊⠝⠊⠍⠀</row>
+                    <row>⠧⠑⠝⠊⠁⠍⠂⠀⠟⠥⠊⠎⠀⠝⠕⠎⠞⠗⠥⠙⠀</row>
+                    <row>⠑⠭⠑⠗⠉⠊⠞⠁⠞⠊⠕⠝⠀⠥⠇⠇⠁⠍⠉⠕⠀⠇⠁⠃⠕⠤</row>
+                    <row>⠗⠊⠎⠀⠝⠊⠎⠊⠀⠥⠞⠀⠁⠇⠊⠟⠥⠊⠏⠀⠑⠭⠀⠑⠁⠀</row>
+                    <row>⠉⠕⠍⠍⠕⠙⠕⠀⠉⠕⠝⠎⠑⠟⠥⠁⠞⠄⠀⠠⠙⠥⠊⠎⠀</row>
+                    <row>⠁⠥⠞⠑⠀⠊⠗⠥⠗⠑⠀⠙⠕⠇⠕⠗⠀⠊⠝⠀⠗⠑⠏⠗⠑⠤</row>
+                    <row>⠓⠑⠝⠙⠑⠗⠊⠞⠀⠊⠝⠀⠧⠕⠇⠥⠏⠞⠁⠞⠑⠀⠧⠑⠇⠊⠞</row>
+                </page>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠁⠑</row>
+                    <row>⠑⠎⠎⠑⠀⠉⠊⠇⠇⠥⠍⠀⠙⠕⠇⠕⠗⠑⠀⠑⠥⠀⠋⠥⠛⠊⠤</row>
+                    <row>⠁⠞⠀⠝⠥⠇⠇⠁⠀⠏⠁⠗⠊⠁⠞⠥⠗⠄⠀⠠⠑⠭⠉⠑⠏⠤</row>
+                    <row>⠞⠑⠥⠗⠀⠎⠊⠝⠞⠀⠕⠉⠉⠁⠑⠉⠁⠞⠀⠉⠥⠏⠊⠙⠁⠤</row>
+                    <row>⠞⠁⠞⠀⠝⠕⠝⠀⠏⠗⠕⠊⠙⠑⠝⠞⠂⠀⠎⠥⠝⠞⠀⠊⠝⠀</row>
+                    <row>⠉⠥⠇⠏⠁⠀⠟⠥⠊⠀⠕⠋⠋⠊⠉⠊⠁⠀⠙⠑⠎⠑⠗⠥⠝⠞⠀</row>
+                    <row>⠍⠕⠇⠇⠊⠞⠀⠁⠝⠊⠍⠀⠊⠙⠀⠑⠎⠞⠀⠇⠁⠃⠕⠗⠥⠍⠄</row>
+                </page>
+                <page>
+                    <row>⠼⠁⠋⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row/>
+                    <row>⠠⠇⠕⠏⠏⠥⠎⠁⠝⠁⠞</row>
+                    <row/>
+                    <row>⠀⠀⠠⠇⠕⠗⠑⠍⠀⠊⠏⠎⠥⠍⠀⠙⠕⠇⠕⠗⠀⠎⠊⠞⠀</row>
+                    <row>⠁⠍⠑⠞⠂⠀⠉⠕⠝⠎⠑⠉⠞⠑⠞⠥⠗⠀⠁⠙⠊⠤</row>
+                    <row>⠏⠊⠎⠉⠊⠝⠛⠀⠑⠇⠊⠞⠂⠀⠎⠑⠙⠀⠙⠕⠀⠑⠊⠥⠎⠤</row>
+                    <row>⠍⠕⠙⠀⠞⠑⠍⠏⠕⠗⠀⠊⠝⠉⠊⠙⠊⠙⠥⠝⠞⠀⠥⠞⠀</row>
+                </page>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠁⠛</row>
+                    <row>⠇⠁⠃⠕⠗⠑⠀⠑⠞⠀⠙⠕⠇⠕⠗⠑⠀⠍⠁⠛⠝⠁⠀</row>
+                    <row>⠁⠇⠊⠟⠥⠁⠄⠀⠠⠥⠞⠀⠑⠝⠊⠍⠀⠁⠙⠀⠍⠊⠝⠊⠍⠀</row>
+                    <row>⠧⠑⠝⠊⠁⠍⠂⠀⠟⠥⠊⠎⠀⠝⠕⠎⠞⠗⠥⠙⠀</row>
+                    <row>⠑⠭⠑⠗⠉⠊⠞⠁⠞⠊⠕⠝⠀⠥⠇⠇⠁⠍⠉⠕⠀⠇⠁⠃⠕⠤</row>
+                    <row>⠗⠊⠎⠀⠝⠊⠎⠊⠀⠥⠞⠀⠁⠇⠊⠟⠥⠊⠏⠀⠑⠭⠀⠑⠁⠀</row>
+                    <row>⠉⠕⠍⠍⠕⠙⠕⠀⠉⠕⠝⠎⠑⠟⠥⠁⠞⠄⠀⠠⠙⠥⠊⠎⠀</row>
+                    <row>⠁⠥⠞⠑⠀⠊⠗⠥⠗⠑⠀⠙⠕⠇⠕⠗⠀⠊⠝⠀⠗⠑⠏⠗⠑⠤</row>
+                </page>
+                <page>
+                    <row>⠼⠁⠓⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row>⠓⠑⠝⠙⠑⠗⠊⠞⠀⠊⠝⠀⠧⠕⠇⠥⠏⠞⠁⠞⠑⠀⠧⠑⠇⠊⠞</row>
+                    <row>⠑⠎⠎⠑⠀⠉⠊⠇⠇⠥⠍⠀⠙⠕⠇⠕⠗⠑⠀⠑⠥⠀⠋⠥⠛⠊⠤</row>
+                    <row>⠁⠞⠀⠝⠥⠇⠇⠁⠀⠏⠁⠗⠊⠁⠞⠥⠗⠄⠀⠠⠑⠭⠉⠑⠏⠤</row>
+                    <row>⠞⠑⠥⠗⠀⠎⠊⠝⠞⠀⠕⠉⠉⠁⠑⠉⠁⠞⠀⠉⠥⠏⠊⠙⠁⠤</row>
+                    <row>⠞⠁⠞⠀⠝⠕⠝⠀⠏⠗⠕⠊⠙⠑⠝⠞⠂⠀⠎⠥⠝⠞⠀⠊⠝⠀</row>
+                    <row>⠉⠥⠇⠏⠁⠀⠟⠥⠊⠀⠕⠋⠋⠊⠉⠊⠁⠀⠙⠑⠎⠑⠗⠥⠝⠞⠀</row>
+                    <row>⠍⠕⠇⠇⠊⠞⠀⠁⠝⠊⠍⠀⠊⠙⠀⠑⠎⠞⠀⠇⠁⠃⠕⠗⠥⠍⠄</row>
+                </page>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠁⠊</row>
+                    <row/>
+                    <row>⠠⠅⠊⠗⠚⠁⠝⠀⠇⠕⠏⠏⠥</row>
+                    <row/>
+                    <row>⠀⠀⠠⠞⠜⠓⠜⠝⠀⠏⠜⠜⠞⠞⠽⠊⠀⠅⠊⠗⠚⠁⠀</row>
+                    <row>⠠⠅⠊⠗⠚⠁</row>
+                </page>
+                <page/>
+                <page/>
+            </section>
+        </volume>
+    </body>
+</pef>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
+  <x:scenario label="pad-volume-endings-non-duplex">
+    <x:call step="celia:dtbook-to-pef">
+      <x:input port="source">
+        <x:document type="file" href="../resources/test.xml">
+        </x:document>
+      </x:input>
+      <x:option name="temp-dir" select="$temp-dir"/>
+      <x:option name="pef-output-dir" select="concat($temp-dir, 'pad-volume-endings-non-duplex/output-dir/')"/>
+      <x:option name="toc-depth" select="'0'"/>
+      <x:option name="page-height" select="'8'"/>
+      <x:option name="maximum-number-of-sheets" select="'8'"/>
+      <x:option name="insert-titlepage" select="false()"/>
+      <x:option name="make-volumes-divisible-by-four" select="false()"/>
+      <x:option name="pad-volume-endings" select="true()"/>
+      <x:option name="duplex" select="false()"/>
+    </x:call>
+    <x:context label="pef">
+      <x:document type="file" base-uri="temp-dir" href="pad-volume-endings-non-duplex/output-dir/test.pef"/>
+    </x:context>
+    <x:expect label="result" type="custom" href="http://www.daisy.org/pipeline/modules/braille/pef-utils/library.xpl" step="x:pef-compare">
+      <x:document type="inline">
+        <pef xmlns="http://www.daisy.org/ns/2008/pef" xml:lang="fi" version="2008-1">
+    <head>
+        <meta>
+          <dc:format xmlns:dc="http://purl.org/dc/elements/1.1/">application/x-pef+xml</dc:format>
+          <dc:identifier xmlns:dc="http://purl.org/dc/elements/1.1/">identifier?</dc:identifier>
+          <dc:date xmlns:dc="http://purl.org/dc/elements/1.1/">2016-05-19</dc:date>
+          <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">Kirja</dc:title>
+          <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">John Doe</dc:creator>
+          <dc:language xmlns:dc="http://purl.org/dc/elements/1.1/">fi</dc:language>
+          <dc:publisher xmlns:dc="http://purl.org/dc/elements/1.1/">Celia</dc:publisher>
+        </meta>
+    </head>
+    <body>
+        <volume cols="27" rows="8" rowgap="0" duplex="false">
+            <section>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠁</row>
+                    <row>⠠⠅⠊⠗⠚⠁</row>
+                    <row/>
+                    <row>⠠⠚⠕⠓⠝⠀⠠⠙⠕⠑</row>
+                    <row/>
+                    <row>⠠⠁⠇⠅⠥⠞⠊⠑⠙⠕⠞</row>
+                    <row/>
+                    <row>⠠⠠⠅⠥⠎⠞⠁⠝⠞⠁⠚⠁⠀⠠⠠⠏⠁⠊⠅⠅⠁</row>
+                </page>
+                <page>
+                    <row>⠼⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row/>
+                    <row>⠠⠧⠊⠊⠙⠑⠎⠀⠏⠁⠊⠝⠕⠎⠂⠀⠼⠃⠚⠁⠑</row>
+                    <row/>
+                    <row>⠠⠞⠥⠕⠞⠞⠁⠚⠁⠒⠀⠠⠉⠑⠇⠊⠁⠀⠤⠀⠠⠝⠜⠅⠪⠤</row>
+                    <row>⠧⠁⠍⠍⠁⠊⠎⠞⠑⠝⠀⠅⠊⠗⠚⠁⠎⠞⠕⠀⠼⠃⠚⠁⠋</row>
+                </page>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠉</row>
+                    <row/>
+                    <row>⠠⠅⠜⠽⠞⠞⠪⠕⠊⠅⠑⠥⠎</row>
+                    <row/>
+                    <row>⠠⠞⠜⠍⠜⠀⠅⠊⠗⠚⠁⠀⠕⠝⠀⠧⠁⠇⠍⠊⠎⠞⠑⠞⠞⠥⠀</row>
+                    <row>⠞⠑⠅⠊⠚⠜⠝⠕⠊⠅⠑⠥⠎⠇⠁⠊⠝⠀⠼⠁⠛⠄⠀⠏⠽⠤</row>
+                    <row>⠅⠜⠇⠜⠝⠀⠝⠕⠚⠁⠇⠇⠁⠀⠚⠁⠀⠕⠝⠀⠞⠁⠗⠅⠕⠊⠤</row>
+                    <row>⠞⠑⠞⠞⠥⠀⠁⠊⠝⠕⠁⠎⠞⠁⠁⠝⠀⠝⠜⠅⠪⠧⠁⠍⠤</row>
+                </page>
+                <page>
+                    <row>⠼⠙⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row>⠍⠁⠊⠎⠞⠑⠝⠀⠚⠁⠀⠍⠥⠊⠙⠑⠝⠀⠇⠥⠅⠑⠍⠊⠤</row>
+                    <row>⠎⠑⠎⠞⠑⠊⠎⠞⠑⠝⠀⠅⠜⠽⠞⠞⠪⠪⠝⠄</row>
+                    <row/>
+                    <row>⠠⠅⠥⠎⠞⠁⠝⠞⠁⠚⠁⠀⠑⠎⠊⠞⠞⠑⠇⠑⠑</row>
+                    <row/>
+                    <row>⠠⠇⠕⠗⠑⠍⠀⠊⠏⠎⠥⠍⠀⠙⠕⠇⠕⠗⠀⠎⠊⠞⠀</row>
+                    <row>⠁⠍⠑⠞⠂⠀⠉⠕⠝⠎⠑⠉⠞⠑⠞⠥⠗⠀⠁⠙⠊⠤</row>
+                </page>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠑</row>
+                    <row>⠏⠊⠎⠉⠊⠝⠛⠀⠑⠇⠊⠞⠂⠀⠎⠑⠙⠀⠙⠕⠀⠑⠊⠥⠎⠤</row>
+                    <row>⠍⠕⠙⠀⠞⠑⠍⠏⠕⠗⠀⠊⠝⠉⠊⠙⠊⠙⠥⠝⠞⠀⠥⠞⠀</row>
+                    <row>⠇⠁⠃⠕⠗⠑⠀⠑⠞⠀⠙⠕⠇⠕⠗⠑⠀⠍⠁⠛⠝⠁⠀</row>
+                    <row>⠁⠇⠊⠟⠥⠁⠄⠀⠠⠥⠞⠀⠑⠝⠊⠍⠀⠁⠙⠀⠍⠊⠝⠊⠍⠀</row>
+                    <row>⠧⠑⠝⠊⠁⠍⠂⠀⠟⠥⠊⠎⠀⠝⠕⠎⠞⠗⠥⠙⠀</row>
+                    <row>⠑⠭⠑⠗⠉⠊⠞⠁⠞⠊⠕⠝⠀⠥⠇⠇⠁⠍⠉⠕⠀⠇⠁⠃⠕⠤</row>
+                    <row>⠗⠊⠎⠀⠝⠊⠎⠊⠀⠥⠞⠀⠁⠇⠊⠟⠥⠊⠏⠀⠑⠭⠀⠑⠁⠀</row>
+                </page>
+                <page>
+                    <row>⠼⠋⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row>⠉⠕⠍⠍⠕⠙⠕⠀⠉⠕⠝⠎⠑⠟⠥⠁⠞⠄⠀⠠⠙⠥⠊⠎⠀</row>
+                    <row>⠁⠥⠞⠑⠀⠊⠗⠥⠗⠑⠀⠙⠕⠇⠕⠗⠀⠊⠝⠀⠗⠑⠏⠗⠑⠤</row>
+                    <row>⠓⠑⠝⠙⠑⠗⠊⠞⠀⠊⠝⠀⠧⠕⠇⠥⠏⠞⠁⠞⠑⠀⠧⠑⠇⠊⠞</row>
+                    <row>⠑⠎⠎⠑⠀⠉⠊⠇⠇⠥⠍⠀⠙⠕⠇⠕⠗⠑⠀⠑⠥⠀⠋⠥⠛⠊⠤</row>
+                    <row>⠁⠞⠀⠝⠥⠇⠇⠁⠀⠏⠁⠗⠊⠁⠞⠥⠗⠄⠀⠠⠑⠭⠉⠑⠏⠤</row>
+                    <row>⠞⠑⠥⠗⠀⠎⠊⠝⠞⠀⠕⠉⠉⠁⠑⠉⠁⠞⠀⠉⠥⠏⠊⠙⠁⠤</row>
+                    <row>⠞⠁⠞⠀⠝⠕⠝⠀⠏⠗⠕⠊⠙⠑⠝⠞⠂⠀⠎⠥⠝⠞⠀⠊⠝⠀</row>
+                </page>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠛</row>
+                    <row>⠉⠥⠇⠏⠁⠀⠟⠥⠊⠀⠕⠋⠋⠊⠉⠊⠁⠀⠙⠑⠎⠑⠗⠥⠝⠞⠀</row>
+                    <row>⠍⠕⠇⠇⠊⠞⠀⠁⠝⠊⠍⠀⠊⠙⠀⠑⠎⠞⠀⠇⠁⠃⠕⠗⠥⠍⠄</row>
+                    <row/>
+                    <row>⠼⠁⠀⠠⠇⠕⠗⠑⠍⠀⠊⠏⠎⠥⠍</row>
+                    <row/>
+                    <row>⠀⠀⠠⠇⠕⠗⠑⠍⠀⠊⠏⠎⠥⠍⠀⠙⠕⠇⠕⠗⠀⠎⠊⠞⠀</row>
+                    <row>⠁⠍⠑⠞⠂⠀⠉⠕⠝⠎⠑⠉⠞⠑⠞⠥⠗⠀⠁⠙⠊⠤</row>
+                </page>
+                <page/>
+            </section>
+        </volume>
+        <volume cols="27" rows="8" rowgap="0" duplex="false">
+            <section>
+                <page>
+                    <row>⠼⠓⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row>⠏⠊⠎⠉⠊⠝⠛⠀⠑⠇⠊⠞⠂⠀⠎⠑⠙⠀⠙⠕⠀⠑⠊⠥⠎⠤</row>
+                    <row>⠍⠕⠙⠀⠞⠑⠍⠏⠕⠗⠀⠊⠝⠉⠊⠙⠊⠙⠥⠝⠞⠀⠥⠞⠀</row>
+                    <row>⠇⠁⠃⠕⠗⠑⠀⠑⠞⠀⠙⠕⠇⠕⠗⠑⠀⠍⠁⠛⠝⠁⠀</row>
+                    <row>⠁⠇⠊⠟⠥⠁⠄⠀⠠⠥⠞⠀⠑⠝⠊⠍⠀⠁⠙⠀⠍⠊⠝⠊⠍⠀</row>
+                    <row>⠧⠑⠝⠊⠁⠍⠂⠀⠟⠥⠊⠎⠀⠝⠕⠎⠞⠗⠥⠙⠀</row>
+                    <row>⠑⠭⠑⠗⠉⠊⠞⠁⠞⠊⠕⠝⠀⠥⠇⠇⠁⠍⠉⠕⠀⠇⠁⠃⠕⠤</row>
+                    <row>⠗⠊⠎⠀⠝⠊⠎⠊⠀⠥⠞⠀⠁⠇⠊⠟⠥⠊⠏⠀⠑⠭⠀⠑⠁⠀</row>
+                </page>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠊</row>
+                    <row>⠉⠕⠍⠍⠕⠙⠕⠀⠉⠕⠝⠎⠑⠟⠥⠁⠞⠄⠀⠠⠙⠥⠊⠎⠀</row>
+                    <row>⠁⠥⠞⠑⠀⠊⠗⠥⠗⠑⠀⠙⠕⠇⠕⠗⠀⠊⠝⠀⠗⠑⠏⠗⠑⠤</row>
+                    <row>⠓⠑⠝⠙⠑⠗⠊⠞⠀⠊⠝⠀⠧⠕⠇⠥⠏⠞⠁⠞⠑⠀⠧⠑⠇⠊⠞</row>
+                    <row>⠑⠎⠎⠑⠀⠉⠊⠇⠇⠥⠍⠀⠙⠕⠇⠕⠗⠑⠀⠑⠥⠀⠋⠥⠛⠊⠤</row>
+                    <row>⠁⠞⠀⠝⠥⠇⠇⠁⠀⠏⠁⠗⠊⠁⠞⠥⠗⠄⠀⠠⠑⠭⠉⠑⠏⠤</row>
+                    <row>⠞⠑⠥⠗⠀⠎⠊⠝⠞⠀⠕⠉⠉⠁⠑⠉⠁⠞⠀⠉⠥⠏⠊⠙⠁⠤</row>
+                    <row>⠞⠁⠞⠀⠝⠕⠝⠀⠏⠗⠕⠊⠙⠑⠝⠞⠂⠀⠎⠥⠝⠞⠀⠊⠝⠀</row>
+                </page>
+                <page>
+                    <row>⠼⠁⠚⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row>⠉⠥⠇⠏⠁⠀⠟⠥⠊⠀⠕⠋⠋⠊⠉⠊⠁⠀⠙⠑⠎⠑⠗⠥⠝⠞⠀</row>
+                    <row>⠍⠕⠇⠇⠊⠞⠀⠁⠝⠊⠍⠀⠊⠙⠀⠑⠎⠞⠀⠇⠁⠃⠕⠗⠥⠍⠄</row>
+                    <row/>
+                    <row>⠠⠇⠕⠗⠑⠍⠀⠊⠏⠎⠥⠍</row>
+                    <row/>
+                    <row>⠀⠀⠠⠇⠕⠗⠑⠍⠀⠊⠏⠎⠥⠍⠀⠙⠕⠇⠕⠗⠀⠎⠊⠞⠀</row>
+                    <row>⠁⠍⠑⠞⠂⠀⠉⠕⠝⠎⠑⠉⠞⠑⠞⠥⠗⠀⠁⠙⠊⠤</row>
+                </page>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠁⠁</row>
+                    <row>⠏⠊⠎⠉⠊⠝⠛⠀⠑⠇⠊⠞⠂⠀⠎⠑⠙⠀⠙⠕⠀⠑⠊⠥⠎⠤</row>
+                    <row>⠍⠕⠙⠀⠞⠑⠍⠏⠕⠗⠀⠊⠝⠉⠊⠙⠊⠙⠥⠝⠞⠀⠥⠞⠀</row>
+                    <row>⠇⠁⠃⠕⠗⠑⠀⠑⠞⠀⠙⠕⠇⠕⠗⠑⠀⠍⠁⠛⠝⠁⠀</row>
+                    <row>⠁⠇⠊⠟⠥⠁⠄⠀⠠⠥⠞⠀⠑⠝⠊⠍⠀⠁⠙⠀⠍⠊⠝⠊⠍⠀</row>
+                    <row>⠧⠑⠝⠊⠁⠍⠂⠀⠟⠥⠊⠎⠀⠝⠕⠎⠞⠗⠥⠙⠀</row>
+                    <row>⠑⠭⠑⠗⠉⠊⠞⠁⠞⠊⠕⠝⠀⠥⠇⠇⠁⠍⠉⠕⠀⠇⠁⠃⠕⠤</row>
+                    <row>⠗⠊⠎⠀⠝⠊⠎⠊⠀⠥⠞⠀⠁⠇⠊⠟⠥⠊⠏⠀⠑⠭⠀⠑⠁⠀</row>
+                </page>
+                <page>
+                    <row>⠼⠁⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row>⠉⠕⠍⠍⠕⠙⠕⠀⠉⠕⠝⠎⠑⠟⠥⠁⠞⠄⠀⠠⠙⠥⠊⠎⠀</row>
+                    <row>⠁⠥⠞⠑⠀⠊⠗⠥⠗⠑⠀⠙⠕⠇⠕⠗⠀⠊⠝⠀⠗⠑⠏⠗⠑⠤</row>
+                    <row>⠓⠑⠝⠙⠑⠗⠊⠞⠀⠊⠝⠀⠧⠕⠇⠥⠏⠞⠁⠞⠑⠀⠧⠑⠇⠊⠞</row>
+                    <row>⠑⠎⠎⠑⠀⠉⠊⠇⠇⠥⠍⠀⠙⠕⠇⠕⠗⠑⠀⠑⠥⠀⠋⠥⠛⠊⠤</row>
+                    <row>⠁⠞⠀⠝⠥⠇⠇⠁⠀⠏⠁⠗⠊⠁⠞⠥⠗⠄⠀⠠⠑⠭⠉⠑⠏⠤</row>
+                    <row>⠞⠑⠥⠗⠀⠎⠊⠝⠞⠀⠕⠉⠉⠁⠑⠉⠁⠞⠀⠉⠥⠏⠊⠙⠁⠤</row>
+                    <row>⠞⠁⠞⠀⠝⠕⠝⠀⠏⠗⠕⠊⠙⠑⠝⠞⠂⠀⠎⠥⠝⠞⠀⠊⠝⠀</row>
+                </page>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠁⠉</row>
+                    <row>⠉⠥⠇⠏⠁⠀⠟⠥⠊⠀⠕⠋⠋⠊⠉⠊⠁⠀⠙⠑⠎⠑⠗⠥⠝⠞⠀</row>
+                    <row>⠍⠕⠇⠇⠊⠞⠀⠁⠝⠊⠍⠀⠊⠙⠀⠑⠎⠞⠀⠇⠁⠃⠕⠗⠥⠍⠄</row>
+                    <row>⠀⠀⠠⠇⠕⠗⠑⠍⠀⠊⠏⠎⠥⠍⠀⠙⠕⠇⠕⠗⠀⠎⠊⠞⠀</row>
+                    <row>⠁⠍⠑⠞⠂⠀⠉⠕⠝⠎⠑⠉⠞⠑⠞⠥⠗⠀⠁⠙⠊⠤</row>
+                    <row>⠏⠊⠎⠉⠊⠝⠛⠀⠑⠇⠊⠞⠂⠀⠎⠑⠙⠀⠙⠕⠀⠑⠊⠥⠎⠤</row>
+                    <row>⠍⠕⠙⠀⠞⠑⠍⠏⠕⠗⠀⠊⠝⠉⠊⠙⠊⠙⠥⠝⠞⠀⠥⠞⠀</row>
+                    <row>⠇⠁⠃⠕⠗⠑⠀⠑⠞⠀⠙⠕⠇⠕⠗⠑⠀⠍⠁⠛⠝⠁⠀</row>
+                </page>
+                <page/>
+            </section>
+        </volume>
+        <volume cols="27" rows="8" rowgap="0" duplex="false">
+            <section>
+                <page>
+                    <row>⠼⠁⠙⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row>⠁⠇⠊⠟⠥⠁⠄⠀⠠⠥⠞⠀⠑⠝⠊⠍⠀⠁⠙⠀⠍⠊⠝⠊⠍⠀</row>
+                    <row>⠧⠑⠝⠊⠁⠍⠂⠀⠟⠥⠊⠎⠀⠝⠕⠎⠞⠗⠥⠙⠀</row>
+                    <row>⠑⠭⠑⠗⠉⠊⠞⠁⠞⠊⠕⠝⠀⠥⠇⠇⠁⠍⠉⠕⠀⠇⠁⠃⠕⠤</row>
+                    <row>⠗⠊⠎⠀⠝⠊⠎⠊⠀⠥⠞⠀⠁⠇⠊⠟⠥⠊⠏⠀⠑⠭⠀⠑⠁⠀</row>
+                    <row>⠉⠕⠍⠍⠕⠙⠕⠀⠉⠕⠝⠎⠑⠟⠥⠁⠞⠄⠀⠠⠙⠥⠊⠎⠀</row>
+                    <row>⠁⠥⠞⠑⠀⠊⠗⠥⠗⠑⠀⠙⠕⠇⠕⠗⠀⠊⠝⠀⠗⠑⠏⠗⠑⠤</row>
+                    <row>⠓⠑⠝⠙⠑⠗⠊⠞⠀⠊⠝⠀⠧⠕⠇⠥⠏⠞⠁⠞⠑⠀⠧⠑⠇⠊⠞</row>
+                </page>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠁⠑</row>
+                    <row>⠑⠎⠎⠑⠀⠉⠊⠇⠇⠥⠍⠀⠙⠕⠇⠕⠗⠑⠀⠑⠥⠀⠋⠥⠛⠊⠤</row>
+                    <row>⠁⠞⠀⠝⠥⠇⠇⠁⠀⠏⠁⠗⠊⠁⠞⠥⠗⠄⠀⠠⠑⠭⠉⠑⠏⠤</row>
+                    <row>⠞⠑⠥⠗⠀⠎⠊⠝⠞⠀⠕⠉⠉⠁⠑⠉⠁⠞⠀⠉⠥⠏⠊⠙⠁⠤</row>
+                    <row>⠞⠁⠞⠀⠝⠕⠝⠀⠏⠗⠕⠊⠙⠑⠝⠞⠂⠀⠎⠥⠝⠞⠀⠊⠝⠀</row>
+                    <row>⠉⠥⠇⠏⠁⠀⠟⠥⠊⠀⠕⠋⠋⠊⠉⠊⠁⠀⠙⠑⠎⠑⠗⠥⠝⠞⠀</row>
+                    <row>⠍⠕⠇⠇⠊⠞⠀⠁⠝⠊⠍⠀⠊⠙⠀⠑⠎⠞⠀⠇⠁⠃⠕⠗⠥⠍⠄</row>
+                </page>
+                <page>
+                    <row>⠼⠁⠋⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row/>
+                    <row>⠠⠇⠕⠏⠏⠥⠎⠁⠝⠁⠞</row>
+                    <row/>
+                    <row>⠀⠀⠠⠇⠕⠗⠑⠍⠀⠊⠏⠎⠥⠍⠀⠙⠕⠇⠕⠗⠀⠎⠊⠞⠀</row>
+                    <row>⠁⠍⠑⠞⠂⠀⠉⠕⠝⠎⠑⠉⠞⠑⠞⠥⠗⠀⠁⠙⠊⠤</row>
+                    <row>⠏⠊⠎⠉⠊⠝⠛⠀⠑⠇⠊⠞⠂⠀⠎⠑⠙⠀⠙⠕⠀⠑⠊⠥⠎⠤</row>
+                    <row>⠍⠕⠙⠀⠞⠑⠍⠏⠕⠗⠀⠊⠝⠉⠊⠙⠊⠙⠥⠝⠞⠀⠥⠞⠀</row>
+                </page>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠁⠛</row>
+                    <row>⠇⠁⠃⠕⠗⠑⠀⠑⠞⠀⠙⠕⠇⠕⠗⠑⠀⠍⠁⠛⠝⠁⠀</row>
+                    <row>⠁⠇⠊⠟⠥⠁⠄⠀⠠⠥⠞⠀⠑⠝⠊⠍⠀⠁⠙⠀⠍⠊⠝⠊⠍⠀</row>
+                    <row>⠧⠑⠝⠊⠁⠍⠂⠀⠟⠥⠊⠎⠀⠝⠕⠎⠞⠗⠥⠙⠀</row>
+                    <row>⠑⠭⠑⠗⠉⠊⠞⠁⠞⠊⠕⠝⠀⠥⠇⠇⠁⠍⠉⠕⠀⠇⠁⠃⠕⠤</row>
+                    <row>⠗⠊⠎⠀⠝⠊⠎⠊⠀⠥⠞⠀⠁⠇⠊⠟⠥⠊⠏⠀⠑⠭⠀⠑⠁⠀</row>
+                    <row>⠉⠕⠍⠍⠕⠙⠕⠀⠉⠕⠝⠎⠑⠟⠥⠁⠞⠄⠀⠠⠙⠥⠊⠎⠀</row>
+                    <row>⠁⠥⠞⠑⠀⠊⠗⠥⠗⠑⠀⠙⠕⠇⠕⠗⠀⠊⠝⠀⠗⠑⠏⠗⠑⠤</row>
+                </page>
+                <page>
+                    <row>⠼⠁⠓⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row>⠓⠑⠝⠙⠑⠗⠊⠞⠀⠊⠝⠀⠧⠕⠇⠥⠏⠞⠁⠞⠑⠀⠧⠑⠇⠊⠞</row>
+                    <row>⠑⠎⠎⠑⠀⠉⠊⠇⠇⠥⠍⠀⠙⠕⠇⠕⠗⠑⠀⠑⠥⠀⠋⠥⠛⠊⠤</row>
+                    <row>⠁⠞⠀⠝⠥⠇⠇⠁⠀⠏⠁⠗⠊⠁⠞⠥⠗⠄⠀⠠⠑⠭⠉⠑⠏⠤</row>
+                    <row>⠞⠑⠥⠗⠀⠎⠊⠝⠞⠀⠕⠉⠉⠁⠑⠉⠁⠞⠀⠉⠥⠏⠊⠙⠁⠤</row>
+                    <row>⠞⠁⠞⠀⠝⠕⠝⠀⠏⠗⠕⠊⠙⠑⠝⠞⠂⠀⠎⠥⠝⠞⠀⠊⠝⠀</row>
+                    <row>⠉⠥⠇⠏⠁⠀⠟⠥⠊⠀⠕⠋⠋⠊⠉⠊⠁⠀⠙⠑⠎⠑⠗⠥⠝⠞⠀</row>
+                    <row>⠍⠕⠇⠇⠊⠞⠀⠁⠝⠊⠍⠀⠊⠙⠀⠑⠎⠞⠀⠇⠁⠃⠕⠗⠥⠍⠄</row>
+                </page>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠁⠊</row>
+                    <row/>
+                    <row>⠠⠅⠊⠗⠚⠁⠝⠀⠇⠕⠏⠏⠥</row>
+                    <row/>
+                    <row>⠀⠀⠠⠞⠜⠓⠜⠝⠀⠏⠜⠜⠞⠞⠽⠊⠀⠅⠊⠗⠚⠁⠀</row>
+                    <row>⠠⠅⠊⠗⠚⠁</row>
+                </page>
+                <page/>
+            </section>
+        </volume>
+    </body>
+</pef>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
 </x:description>

--- a/src/test/xprocspec/test_script.xprocspec
+++ b/src/test/xprocspec/test_script.xprocspec
@@ -2023,4 +2023,249 @@
     </x:expect>
   </x:scenario>
 
+  <x:scenario label="volumes-divisible-by-four-non-duplex">
+    <x:call step="celia:dtbook-to-pef">
+      <x:input port="source">
+        <x:document type="file" href="../resources/test.xml">
+        </x:document>
+      </x:input>
+      <x:option name="temp-dir" select="$temp-dir"/>
+      <x:option name="pef-output-dir" select="concat($temp-dir, 'volumes-divisible-by-four-non-duplex/output-dir/')"/>
+      <x:option name="toc-depth" select="'0'"/>
+      <x:option name="page-height" select="'8'"/>
+      <x:option name="maximum-number-of-sheets" select="'4'"/>
+      <x:option name="insert-titlepage" select="false()"/>
+      <x:option name="make-volumes-divisible-by-four" select="true()"/>
+      <x:option name="duplex" select="false()"/>
+    </x:call>
+    <x:context label="pef">
+      <x:document type="file" base-uri="temp-dir" href="volumes-divisible-by-four-non-duplex/output-dir/test.pef"/>
+    </x:context>
+    <x:expect label="result" type="custom" href="http://www.daisy.org/pipeline/modules/braille/pef-utils/library.xpl" step="x:pef-compare">
+      <x:document type="inline">
+        <pef xmlns="http://www.daisy.org/ns/2008/pef" xml:lang="fi" version="2008-1">
+    <head>
+        <meta>
+            <dc:format xmlns:dc="http://purl.org/dc/elements/1.1/">application/x-pef+xml</dc:format>
+            <dc:identifier xmlns:dc="http://purl.org/dc/elements/1.1/">identifier?</dc:identifier>
+            <dc:date xmlns:dc="http://purl.org/dc/elements/1.1/">2016-05-18</dc:date>
+            <dc:title xmlns:dc="http://purl.org/dc/elements/1.1/">Kirja</dc:title>
+            <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">John Doe</dc:creator>
+            <dc:language xmlns:dc="http://purl.org/dc/elements/1.1/">fi</dc:language>
+            <dc:publisher xmlns:dc="http://purl.org/dc/elements/1.1/">Celia</dc:publisher>
+        </meta>
+    </head>
+    <body>
+        <volume cols="27" rows="8" rowgap="0" duplex="false">
+            <section>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠁</row>
+                    <row>⠠⠅⠊⠗⠚⠁</row>
+                    <row/>
+                    <row>⠠⠚⠕⠓⠝⠀⠠⠙⠕⠑</row>
+                    <row/>
+                    <row>⠠⠁⠇⠅⠥⠞⠊⠑⠙⠕⠞</row>
+                    <row/>
+                    <row>⠠⠠⠅⠥⠎⠞⠁⠝⠞⠁⠚⠁⠀⠠⠠⠏⠁⠊⠅⠅⠁</row>
+                </page>
+                <page>
+                    <row>⠼⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row/>
+                    <row>⠠⠧⠊⠊⠙⠑⠎⠀⠏⠁⠊⠝⠕⠎⠂⠀⠼⠃⠚⠁⠑</row>
+                    <row/>
+                    <row>⠠⠞⠥⠕⠞⠞⠁⠚⠁⠒⠀⠠⠉⠑⠇⠊⠁⠀⠤⠀⠠⠝⠜⠅⠪⠤</row>
+                    <row>⠧⠁⠍⠍⠁⠊⠎⠞⠑⠝⠀⠅⠊⠗⠚⠁⠎⠞⠕⠀⠼⠃⠚⠁⠋</row>
+                </page>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠉</row>
+                    <row/>
+                    <row>⠠⠅⠜⠽⠞⠞⠪⠕⠊⠅⠑⠥⠎</row>
+                    <row/>
+                    <row>⠠⠞⠜⠍⠜⠀⠅⠊⠗⠚⠁⠀⠕⠝⠀⠧⠁⠇⠍⠊⠎⠞⠑⠞⠞⠥⠀</row>
+                    <row>⠞⠑⠅⠊⠚⠜⠝⠕⠊⠅⠑⠥⠎⠇⠁⠊⠝⠀⠼⠁⠛⠄⠀⠏⠽⠤</row>
+                    <row>⠅⠜⠇⠜⠝⠀⠝⠕⠚⠁⠇⠇⠁⠀⠚⠁⠀⠕⠝⠀⠞⠁⠗⠅⠕⠊⠤</row>
+                    <row>⠞⠑⠞⠞⠥⠀⠁⠊⠝⠕⠁⠎⠞⠁⠁⠝⠀⠝⠜⠅⠪⠧⠁⠍⠤</row>
+                </page>
+                <page>
+                    <row>⠼⠙⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row>⠍⠁⠊⠎⠞⠑⠝⠀⠚⠁⠀⠍⠥⠊⠙⠑⠝⠀⠇⠥⠅⠑⠍⠊⠤</row>
+                    <row>⠎⠑⠎⠞⠑⠊⠎⠞⠑⠝⠀⠅⠜⠽⠞⠞⠪⠪⠝⠄</row>
+                    <row/>
+                    <row>⠠⠅⠥⠎⠞⠁⠝⠞⠁⠚⠁⠀⠑⠎⠊⠞⠞⠑⠇⠑⠑</row>
+                    <row/>
+                    <row>⠠⠇⠕⠗⠑⠍⠀⠊⠏⠎⠥⠍⠀⠙⠕⠇⠕⠗⠀⠎⠊⠞⠀</row>
+                    <row>⠁⠍⠑⠞⠂⠀⠉⠕⠝⠎⠑⠉⠞⠑⠞⠥⠗⠀⠁⠙⠊⠤</row>
+                </page>
+            </section>
+        </volume>
+        <volume cols="27" rows="8" rowgap="0" duplex="false">
+            <section>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠑</row>
+                    <row>⠏⠊⠎⠉⠊⠝⠛⠀⠑⠇⠊⠞⠂⠀⠎⠑⠙⠀⠙⠕⠀⠑⠊⠥⠎⠤</row>
+                    <row>⠍⠕⠙⠀⠞⠑⠍⠏⠕⠗⠀⠊⠝⠉⠊⠙⠊⠙⠥⠝⠞⠀⠥⠞⠀</row>
+                    <row>⠇⠁⠃⠕⠗⠑⠀⠑⠞⠀⠙⠕⠇⠕⠗⠑⠀⠍⠁⠛⠝⠁⠀</row>
+                    <row>⠁⠇⠊⠟⠥⠁⠄⠀⠠⠥⠞⠀⠑⠝⠊⠍⠀⠁⠙⠀⠍⠊⠝⠊⠍⠀</row>
+                    <row>⠧⠑⠝⠊⠁⠍⠂⠀⠟⠥⠊⠎⠀⠝⠕⠎⠞⠗⠥⠙⠀</row>
+                    <row>⠑⠭⠑⠗⠉⠊⠞⠁⠞⠊⠕⠝⠀⠥⠇⠇⠁⠍⠉⠕⠀⠇⠁⠃⠕⠤</row>
+                    <row>⠗⠊⠎⠀⠝⠊⠎⠊⠀⠥⠞⠀⠁⠇⠊⠟⠥⠊⠏⠀⠑⠭⠀⠑⠁⠀</row>
+                </page>
+                <page>
+                    <row>⠼⠋⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row>⠉⠕⠍⠍⠕⠙⠕⠀⠉⠕⠝⠎⠑⠟⠥⠁⠞⠄⠀⠠⠙⠥⠊⠎⠀</row>
+                    <row>⠁⠥⠞⠑⠀⠊⠗⠥⠗⠑⠀⠙⠕⠇⠕⠗⠀⠊⠝⠀⠗⠑⠏⠗⠑⠤</row>
+                    <row>⠓⠑⠝⠙⠑⠗⠊⠞⠀⠊⠝⠀⠧⠕⠇⠥⠏⠞⠁⠞⠑⠀⠧⠑⠇⠊⠞</row>
+                    <row>⠑⠎⠎⠑⠀⠉⠊⠇⠇⠥⠍⠀⠙⠕⠇⠕⠗⠑⠀⠑⠥⠀⠋⠥⠛⠊⠤</row>
+                    <row>⠁⠞⠀⠝⠥⠇⠇⠁⠀⠏⠁⠗⠊⠁⠞⠥⠗⠄⠀⠠⠑⠭⠉⠑⠏⠤</row>
+                    <row>⠞⠑⠥⠗⠀⠎⠊⠝⠞⠀⠕⠉⠉⠁⠑⠉⠁⠞⠀⠉⠥⠏⠊⠙⠁⠤</row>
+                    <row>⠞⠁⠞⠀⠝⠕⠝⠀⠏⠗⠕⠊⠙⠑⠝⠞⠂⠀⠎⠥⠝⠞⠀⠊⠝⠀</row>
+                </page>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠛</row>
+                    <row>⠉⠥⠇⠏⠁⠀⠟⠥⠊⠀⠕⠋⠋⠊⠉⠊⠁⠀⠙⠑⠎⠑⠗⠥⠝⠞⠀</row>
+                    <row>⠍⠕⠇⠇⠊⠞⠀⠁⠝⠊⠍⠀⠊⠙⠀⠑⠎⠞⠀⠇⠁⠃⠕⠗⠥⠍⠄</row>
+                    <row/>
+                    <row>⠼⠁⠀⠠⠇⠕⠗⠑⠍⠀⠊⠏⠎⠥⠍</row>
+                    <row/>
+                    <row>⠀⠀⠠⠇⠕⠗⠑⠍⠀⠊⠏⠎⠥⠍⠀⠙⠕⠇⠕⠗⠀⠎⠊⠞⠀</row>
+                    <row>⠁⠍⠑⠞⠂⠀⠉⠕⠝⠎⠑⠉⠞⠑⠞⠥⠗⠀⠁⠙⠊⠤</row>
+                </page>
+                <page>
+                    <row>⠼⠓⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row>⠏⠊⠎⠉⠊⠝⠛⠀⠑⠇⠊⠞⠂⠀⠎⠑⠙⠀⠙⠕⠀⠑⠊⠥⠎⠤</row>
+                    <row>⠍⠕⠙⠀⠞⠑⠍⠏⠕⠗⠀⠊⠝⠉⠊⠙⠊⠙⠥⠝⠞⠀⠥⠞⠀</row>
+                    <row>⠇⠁⠃⠕⠗⠑⠀⠑⠞⠀⠙⠕⠇⠕⠗⠑⠀⠍⠁⠛⠝⠁⠀</row>
+                    <row>⠁⠇⠊⠟⠥⠁⠄⠀⠠⠥⠞⠀⠑⠝⠊⠍⠀⠁⠙⠀⠍⠊⠝⠊⠍⠀</row>
+                    <row>⠧⠑⠝⠊⠁⠍⠂⠀⠟⠥⠊⠎⠀⠝⠕⠎⠞⠗⠥⠙⠀</row>
+                    <row>⠑⠭⠑⠗⠉⠊⠞⠁⠞⠊⠕⠝⠀⠥⠇⠇⠁⠍⠉⠕⠀⠇⠁⠃⠕⠤</row>
+                    <row>⠗⠊⠎⠀⠝⠊⠎⠊⠀⠥⠞⠀⠁⠇⠊⠟⠥⠊⠏⠀⠑⠭⠀⠑⠁⠀</row>
+                </page>
+            </section>
+        </volume>
+        <volume cols="27" rows="8" rowgap="0" duplex="false">
+            <section>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠊</row>
+                    <row>⠉⠕⠍⠍⠕⠙⠕⠀⠉⠕⠝⠎⠑⠟⠥⠁⠞⠄⠀⠠⠙⠥⠊⠎⠀</row>
+                    <row>⠁⠥⠞⠑⠀⠊⠗⠥⠗⠑⠀⠙⠕⠇⠕⠗⠀⠊⠝⠀⠗⠑⠏⠗⠑⠤</row>
+                    <row>⠓⠑⠝⠙⠑⠗⠊⠞⠀⠊⠝⠀⠧⠕⠇⠥⠏⠞⠁⠞⠑⠀⠧⠑⠇⠊⠞</row>
+                    <row>⠑⠎⠎⠑⠀⠉⠊⠇⠇⠥⠍⠀⠙⠕⠇⠕⠗⠑⠀⠑⠥⠀⠋⠥⠛⠊⠤</row>
+                    <row>⠁⠞⠀⠝⠥⠇⠇⠁⠀⠏⠁⠗⠊⠁⠞⠥⠗⠄⠀⠠⠑⠭⠉⠑⠏⠤</row>
+                    <row>⠞⠑⠥⠗⠀⠎⠊⠝⠞⠀⠕⠉⠉⠁⠑⠉⠁⠞⠀⠉⠥⠏⠊⠙⠁⠤</row>
+                    <row>⠞⠁⠞⠀⠝⠕⠝⠀⠏⠗⠕⠊⠙⠑⠝⠞⠂⠀⠎⠥⠝⠞⠀⠊⠝⠀</row>
+                </page>
+                <page>
+                    <row>⠼⠁⠚⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row>⠉⠥⠇⠏⠁⠀⠟⠥⠊⠀⠕⠋⠋⠊⠉⠊⠁⠀⠙⠑⠎⠑⠗⠥⠝⠞⠀</row>
+                    <row>⠍⠕⠇⠇⠊⠞⠀⠁⠝⠊⠍⠀⠊⠙⠀⠑⠎⠞⠀⠇⠁⠃⠕⠗⠥⠍⠄</row>
+                    <row/>
+                    <row>⠠⠇⠕⠗⠑⠍⠀⠊⠏⠎⠥⠍</row>
+                    <row/>
+                    <row>⠀⠀⠠⠇⠕⠗⠑⠍⠀⠊⠏⠎⠥⠍⠀⠙⠕⠇⠕⠗⠀⠎⠊⠞⠀</row>
+                    <row>⠁⠍⠑⠞⠂⠀⠉⠕⠝⠎⠑⠉⠞⠑⠞⠥⠗⠀⠁⠙⠊⠤</row>
+                </page>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠁⠁</row>
+                    <row>⠏⠊⠎⠉⠊⠝⠛⠀⠑⠇⠊⠞⠂⠀⠎⠑⠙⠀⠙⠕⠀⠑⠊⠥⠎⠤</row>
+                    <row>⠍⠕⠙⠀⠞⠑⠍⠏⠕⠗⠀⠊⠝⠉⠊⠙⠊⠙⠥⠝⠞⠀⠥⠞⠀</row>
+                    <row>⠇⠁⠃⠕⠗⠑⠀⠑⠞⠀⠙⠕⠇⠕⠗⠑⠀⠍⠁⠛⠝⠁⠀</row>
+                    <row>⠁⠇⠊⠟⠥⠁⠄⠀⠠⠥⠞⠀⠑⠝⠊⠍⠀⠁⠙⠀⠍⠊⠝⠊⠍⠀</row>
+                    <row>⠧⠑⠝⠊⠁⠍⠂⠀⠟⠥⠊⠎⠀⠝⠕⠎⠞⠗⠥⠙⠀</row>
+                    <row>⠑⠭⠑⠗⠉⠊⠞⠁⠞⠊⠕⠝⠀⠥⠇⠇⠁⠍⠉⠕⠀⠇⠁⠃⠕⠤</row>
+                    <row>⠗⠊⠎⠀⠝⠊⠎⠊⠀⠥⠞⠀⠁⠇⠊⠟⠥⠊⠏⠀⠑⠭⠀⠑⠁⠀</row>
+                </page>
+                <page>
+                    <row>⠼⠁⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row>⠉⠕⠍⠍⠕⠙⠕⠀⠉⠕⠝⠎⠑⠟⠥⠁⠞⠄⠀⠠⠙⠥⠊⠎⠀</row>
+                    <row>⠁⠥⠞⠑⠀⠊⠗⠥⠗⠑⠀⠙⠕⠇⠕⠗⠀⠊⠝⠀⠗⠑⠏⠗⠑⠤</row>
+                    <row>⠓⠑⠝⠙⠑⠗⠊⠞⠀⠊⠝⠀⠧⠕⠇⠥⠏⠞⠁⠞⠑⠀⠧⠑⠇⠊⠞</row>
+                    <row>⠑⠎⠎⠑⠀⠉⠊⠇⠇⠥⠍⠀⠙⠕⠇⠕⠗⠑⠀⠑⠥⠀⠋⠥⠛⠊⠤</row>
+                    <row>⠁⠞⠀⠝⠥⠇⠇⠁⠀⠏⠁⠗⠊⠁⠞⠥⠗⠄⠀⠠⠑⠭⠉⠑⠏⠤</row>
+                    <row>⠞⠑⠥⠗⠀⠎⠊⠝⠞⠀⠕⠉⠉⠁⠑⠉⠁⠞⠀⠉⠥⠏⠊⠙⠁⠤</row>
+                    <row>⠞⠁⠞⠀⠝⠕⠝⠀⠏⠗⠕⠊⠙⠑⠝⠞⠂⠀⠎⠥⠝⠞⠀⠊⠝⠀</row>
+                </page>
+            </section>
+        </volume>
+        <volume cols="27" rows="8" rowgap="0" duplex="false">
+            <section>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠁⠉</row>
+                    <row>⠉⠥⠇⠏⠁⠀⠟⠥⠊⠀⠕⠋⠋⠊⠉⠊⠁⠀⠙⠑⠎⠑⠗⠥⠝⠞⠀</row>
+                    <row>⠍⠕⠇⠇⠊⠞⠀⠁⠝⠊⠍⠀⠊⠙⠀⠑⠎⠞⠀⠇⠁⠃⠕⠗⠥⠍⠄</row>
+                    <row>⠀⠀⠠⠇⠕⠗⠑⠍⠀⠊⠏⠎⠥⠍⠀⠙⠕⠇⠕⠗⠀⠎⠊⠞⠀</row>
+                    <row>⠁⠍⠑⠞⠂⠀⠉⠕⠝⠎⠑⠉⠞⠑⠞⠥⠗⠀⠁⠙⠊⠤</row>
+                    <row>⠏⠊⠎⠉⠊⠝⠛⠀⠑⠇⠊⠞⠂⠀⠎⠑⠙⠀⠙⠕⠀⠑⠊⠥⠎⠤</row>
+                    <row>⠍⠕⠙⠀⠞⠑⠍⠏⠕⠗⠀⠊⠝⠉⠊⠙⠊⠙⠥⠝⠞⠀⠥⠞⠀</row>
+                    <row>⠇⠁⠃⠕⠗⠑⠀⠑⠞⠀⠙⠕⠇⠕⠗⠑⠀⠍⠁⠛⠝⠁⠀</row>
+                </page>
+                <page>
+                    <row>⠼⠁⠙⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row>⠁⠇⠊⠟⠥⠁⠄⠀⠠⠥⠞⠀⠑⠝⠊⠍⠀⠁⠙⠀⠍⠊⠝⠊⠍⠀</row>
+                    <row>⠧⠑⠝⠊⠁⠍⠂⠀⠟⠥⠊⠎⠀⠝⠕⠎⠞⠗⠥⠙⠀</row>
+                    <row>⠑⠭⠑⠗⠉⠊⠞⠁⠞⠊⠕⠝⠀⠥⠇⠇⠁⠍⠉⠕⠀⠇⠁⠃⠕⠤</row>
+                    <row>⠗⠊⠎⠀⠝⠊⠎⠊⠀⠥⠞⠀⠁⠇⠊⠟⠥⠊⠏⠀⠑⠭⠀⠑⠁⠀</row>
+                    <row>⠉⠕⠍⠍⠕⠙⠕⠀⠉⠕⠝⠎⠑⠟⠥⠁⠞⠄⠀⠠⠙⠥⠊⠎⠀</row>
+                    <row>⠁⠥⠞⠑⠀⠊⠗⠥⠗⠑⠀⠙⠕⠇⠕⠗⠀⠊⠝⠀⠗⠑⠏⠗⠑⠤</row>
+                    <row>⠓⠑⠝⠙⠑⠗⠊⠞⠀⠊⠝⠀⠧⠕⠇⠥⠏⠞⠁⠞⠑⠀⠧⠑⠇⠊⠞</row>
+                </page>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠁⠑</row>
+                    <row>⠑⠎⠎⠑⠀⠉⠊⠇⠇⠥⠍⠀⠙⠕⠇⠕⠗⠑⠀⠑⠥⠀⠋⠥⠛⠊⠤</row>
+                    <row>⠁⠞⠀⠝⠥⠇⠇⠁⠀⠏⠁⠗⠊⠁⠞⠥⠗⠄⠀⠠⠑⠭⠉⠑⠏⠤</row>
+                    <row>⠞⠑⠥⠗⠀⠎⠊⠝⠞⠀⠕⠉⠉⠁⠑⠉⠁⠞⠀⠉⠥⠏⠊⠙⠁⠤</row>
+                    <row>⠞⠁⠞⠀⠝⠕⠝⠀⠏⠗⠕⠊⠙⠑⠝⠞⠂⠀⠎⠥⠝⠞⠀⠊⠝⠀</row>
+                    <row>⠉⠥⠇⠏⠁⠀⠟⠥⠊⠀⠕⠋⠋⠊⠉⠊⠁⠀⠙⠑⠎⠑⠗⠥⠝⠞⠀</row>
+                    <row>⠍⠕⠇⠇⠊⠞⠀⠁⠝⠊⠍⠀⠊⠙⠀⠑⠎⠞⠀⠇⠁⠃⠕⠗⠥⠍⠄</row>
+                </page>
+                <page>
+                    <row>⠼⠁⠋⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row/>
+                    <row>⠠⠇⠕⠏⠏⠥⠎⠁⠝⠁⠞</row>
+                    <row/>
+                    <row>⠀⠀⠠⠇⠕⠗⠑⠍⠀⠊⠏⠎⠥⠍⠀⠙⠕⠇⠕⠗⠀⠎⠊⠞⠀</row>
+                    <row>⠁⠍⠑⠞⠂⠀⠉⠕⠝⠎⠑⠉⠞⠑⠞⠥⠗⠀⠁⠙⠊⠤</row>
+                    <row>⠏⠊⠎⠉⠊⠝⠛⠀⠑⠇⠊⠞⠂⠀⠎⠑⠙⠀⠙⠕⠀⠑⠊⠥⠎⠤</row>
+                    <row>⠍⠕⠙⠀⠞⠑⠍⠏⠕⠗⠀⠊⠝⠉⠊⠙⠊⠙⠥⠝⠞⠀⠥⠞⠀</row>
+                </page>
+            </section>
+        </volume>
+        <volume cols="27" rows="8" rowgap="0" duplex="false">
+            <section>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠁⠛</row>
+                    <row>⠇⠁⠃⠕⠗⠑⠀⠑⠞⠀⠙⠕⠇⠕⠗⠑⠀⠍⠁⠛⠝⠁⠀</row>
+                    <row>⠁⠇⠊⠟⠥⠁⠄⠀⠠⠥⠞⠀⠑⠝⠊⠍⠀⠁⠙⠀⠍⠊⠝⠊⠍⠀</row>
+                    <row>⠧⠑⠝⠊⠁⠍⠂⠀⠟⠥⠊⠎⠀⠝⠕⠎⠞⠗⠥⠙⠀</row>
+                    <row>⠑⠭⠑⠗⠉⠊⠞⠁⠞⠊⠕⠝⠀⠥⠇⠇⠁⠍⠉⠕⠀⠇⠁⠃⠕⠤</row>
+                    <row>⠗⠊⠎⠀⠝⠊⠎⠊⠀⠥⠞⠀⠁⠇⠊⠟⠥⠊⠏⠀⠑⠭⠀⠑⠁⠀</row>
+                    <row>⠉⠕⠍⠍⠕⠙⠕⠀⠉⠕⠝⠎⠑⠟⠥⠁⠞⠄⠀⠠⠙⠥⠊⠎⠀</row>
+                    <row>⠁⠥⠞⠑⠀⠊⠗⠥⠗⠑⠀⠙⠕⠇⠕⠗⠀⠊⠝⠀⠗⠑⠏⠗⠑⠤</row>
+                </page>
+                <page>
+                    <row>⠼⠁⠓⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</row>
+                    <row>⠓⠑⠝⠙⠑⠗⠊⠞⠀⠊⠝⠀⠧⠕⠇⠥⠏⠞⠁⠞⠑⠀⠧⠑⠇⠊⠞</row>
+                    <row>⠑⠎⠎⠑⠀⠉⠊⠇⠇⠥⠍⠀⠙⠕⠇⠕⠗⠑⠀⠑⠥⠀⠋⠥⠛⠊⠤</row>
+                    <row>⠁⠞⠀⠝⠥⠇⠇⠁⠀⠏⠁⠗⠊⠁⠞⠥⠗⠄⠀⠠⠑⠭⠉⠑⠏⠤</row>
+                    <row>⠞⠑⠥⠗⠀⠎⠊⠝⠞⠀⠕⠉⠉⠁⠑⠉⠁⠞⠀⠉⠥⠏⠊⠙⠁⠤</row>
+                    <row>⠞⠁⠞⠀⠝⠕⠝⠀⠏⠗⠕⠊⠙⠑⠝⠞⠂⠀⠎⠥⠝⠞⠀⠊⠝⠀</row>
+                    <row>⠉⠥⠇⠏⠁⠀⠟⠥⠊⠀⠕⠋⠋⠊⠉⠊⠁⠀⠙⠑⠎⠑⠗⠥⠝⠞⠀</row>
+                    <row>⠍⠕⠇⠇⠊⠞⠀⠁⠝⠊⠍⠀⠊⠙⠀⠑⠎⠞⠀⠇⠁⠃⠕⠗⠥⠍⠄</row>
+                </page>
+                <page>
+                    <row>⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠁⠊</row>
+                    <row/>
+                    <row>⠠⠅⠊⠗⠚⠁⠝⠀⠇⠕⠏⠏⠥</row>
+                    <row/>
+                    <row>⠀⠀⠠⠞⠜⠓⠜⠝⠀⠏⠜⠜⠞⠞⠽⠊⠀⠅⠊⠗⠚⠁⠀</row>
+                    <row>⠠⠅⠊⠗⠚⠁</row>
+                </page>
+                <page/>
+            </section>
+        </volume>
+    </body>
+</pef>
+      </x:document>
+    </x:expect>
+  </x:scenario>
+
 </x:description>


### PR DESCRIPTION
Fix #26 
Adds options for 1. ensuring that there is at least one blank sheet at the end of the book to protect the braille and 2. adding blank pages at the end of volumes to make the number of pages in volume divisible by four.
